### PR TITLE
Pattern fixes

### DIFF
--- a/packages/larva-patterns/components/c-button/c-button.brand-basic.js
+++ b/packages/larva-patterns/components/c-button/c-button.brand-basic.js
@@ -1,0 +1,6 @@
+const c_button_protoype = require( './c-button.prototype' );
+const c_button = Object.assign( {}, c_button_protoype );
+
+c_button.c_button_classes += " lrv-u-padding-tb-050 lrv-u-padding-lr-1 lrv-u-background-color-brand-primary lrv-u-color-white";
+
+module.exports = c_button;

--- a/packages/larva-patterns/components/c-button/c-button.ghost.js
+++ b/packages/larva-patterns/components/c-button/c-button.ghost.js
@@ -1,6 +1,6 @@
 const path = require( 'path' );
-const clone = require( '@penskemediacorp/larva' ).clone;
-const c_button = clone( path.resolve( __dirname, './c-button.prototype' ) );
+const c_button_protoype = require( './c-button.prototype' );
+const c_button = Object.assign( {}, c_button_protoype );
 
 c_button.c_button_classes += "lrv-a-unstyle-button lrv-u-cursor-pointer lrv-u-border-a-3 lrv-u-border-radius-5 lrv-u-color-brand-primary lrv-u-padding-tb-050 lrv-u-padding-lr-1 lrv-u-color-grey-dark:hover lrv-u-font-weight-bold lrv-u-display-inline-block";
 c_button.c_button_type_attr = "";

--- a/packages/larva-patterns/components/c-email-field/c-email-field.ghost.js
+++ b/packages/larva-patterns/components/c-email-field/c-email-field.ghost.js
@@ -1,7 +1,7 @@
 
 const path = require( 'path' );
-const clone = require( '@penskemediacorp/larva' ).clone;// This should be in this repo, probably
-const c_email_field = clone( path.resolve( __dirname, './c-email-field.prototype' ) );
+const c_email_field_prototype = require( './c-email-field.prototype' );
+const c_email_field = Object.assign( {}, c_email_field_prototype );
 
 c_email_field.c_email_field_classes = "lrv-u-font-size-14 lrv-u-flex lrv-u-align-items-center";
 c_email_field.c_email_field_label_classes = "lrv-u-padding-r-050 lrv-u-font-weight-bold lrv-u-whitespace-nowrap";

--- a/packages/larva-patterns/objects/o-email-capture-form/o-email-capture-form.prototype.js
+++ b/packages/larva-patterns/objects/o-email-capture-form/o-email-capture-form.prototype.js
@@ -1,6 +1,9 @@
 const path = require( 'path' );
-const clone = require( '@penskemediacorp/larva' ).clone;
-const c_button = clone( path.resolve( __dirname, '../../components/c-button/c-button.prototype' ) );
+const c_button_prototype = require( '../../components/c-button/c-button.prototype' );
+const c_button = Object.assign( {}, c_button_prototype );
+
+const c_email_field_prototype = require( '../../components/c-email-field/c-email-field.prototype' );
+const c_email_field = Object.assign( {}, c_email_field_prototype );
 
 module.exports = {
 	"o_email_capture_form_classes": "",
@@ -10,17 +13,9 @@ module.exports = {
 	"o_email_capture_form_base_url": "",
 	"o_email_capture_form_input_global_opted_in_bool_name": "Global_Opt_In_Date",
 	"o_email_capture_form_input_global_opted_in_bool_value": "Yes",
-	"o_email_capture_form_input_opted_in_date_name": "Deadline_Breaking_News_Opt_In_Date",
+	"o_email_capture_form_input_opted_in_date_name": "CAMPAIGN_NAME_Opt_In_Date",
 	"o_email_capture_form_input_opted_in_date_value": "00-00-00",
 	"o_email_capture_form_source_value_attr": "onsite-footer",
 	"c_button": c_button,
-	"c_email_field": {
-		"c_email_field_classes": "",
-		"c_email_field_label_classes": "",
-		"c_email_field_label_for_attr": "",
-		"c_email_field_label_text": "Your Email",
-		"c_email_field_input_id_attr": "",
-		"c_email_field_input_name_attr": "",
-		"c_email_field_input_placeholder_attr": "you@email.com"
-	}
+	"c_email_field": c_email_field
 }

--- a/packages/larva-patterns/objects/o-nav/o-nav.horizontal.js
+++ b/packages/larva-patterns/objects/o-nav/o-nav.horizontal.js
@@ -3,6 +3,6 @@ const clone = require( '../../../larva/lib/utils/clonePatternData' );// This sho
 const o_nav = clone( path.resolve( __dirname, '../../objects/o-nav/o-nav.prototype' ) );
 
 o_nav.o_nav_classes = 'lrv-u-flex';
-o_nav.o_nav_list_classes += ' lrv-u-flex lrv-a-space-children-horizontal lrv-a-space-children--1 lrv-u-align-items-center lrv-u-font-family-primary lrv-u-a-unstyle-list';
+o_nav.o_nav_list_classes += ' lrv-u-flex lrv-a-space-children-horizontal lrv-a-space-children--1 lrv-u-align-items-center lrv-u-a-unstyle-list';
 
 module.exports = o_nav;


### PR DESCRIPTION
* Remove a font family class
* Add `brand-basic` c-button variation
* Remove `.clone` method for a few patterns – no longer using that so that text editors can read the actual module and provide hints
* Also remove hard coded `c-email-field` obj from `o-email-capture-form`