### PR TITLE
Support Twig Filters in Parser

### DIFF
--- a/packages/twig-to-php-parser/__tests__/fixtures/src/patterns/04-components/c-logo/c-logo.twig
+++ b/packages/twig-to-php-parser/__tests__/fixtures/src/patterns/04-components/c-logo/c-logo.twig
@@ -1,0 +1,3 @@
+<div>
+	{{ c_logo_markup|raw }}
+</div>

--- a/packages/twig-to-php-parser/__tests__/fixtures/template-parts-expected/patterns/components/c-logo.php
+++ b/packages/twig-to-php-parser/__tests__/fixtures/template-parts-expected/patterns/components/c-logo.php
@@ -1,0 +1,6 @@
+<?php
+// This is a generated file. Refer to the relevant Twig file for adjusting this markup.
+?>
+<div>
+	<?php echo wp_kses_post( $c_logo_markup ?? '' ); ?>
+</div>

--- a/packages/twig-to-php-parser/__tests__/twig-to-php-parser.test.js
+++ b/packages/twig-to-php-parser/__tests__/twig-to-php-parser.test.js
@@ -16,6 +16,7 @@ const patternShortPaths = [
 	'components/c-byline.php',
 	'components/c-heading.php',
 	'components/c-button.php',
+	'components/c-logo.php',
 	'objects/o-nav.php',
 	'objects/o-story-list.php',
 	'modules/trending.php',

--- a/packages/twig-to-php-parser/lib/twig-to-php-parser.php
+++ b/packages/twig-to-php-parser/lib/twig-to-php-parser.php
@@ -129,7 +129,7 @@ function twig_to_php_parser( $patterns_dir_path, $template_dir_path ) {
 
 			// Remove the Twig filter from the variable name
 			if ( $has_filter ) {
-				$string_parts = explode( '|', $variable_name );
+				$string_parts  = explode( '|', $variable_name );
 				$variable_name = $string_parts[0];
 			}
 

--- a/packages/twig-to-php-parser/lib/twig-to-php-parser.php
+++ b/packages/twig-to-php-parser/lib/twig-to-php-parser.php
@@ -64,8 +64,8 @@ function twig_to_php_parser( $patterns_dir_path, $template_dir_path ) {
 		$loop_regex = '/({% for item in\s*)(\w*)/';
 
 		// Get matches for {{ name }}
-		// https://regex101.com/r/ACN0rE/1
-		$mustache_regex = '/({{\s*)(\w*)(\s*}})/';
+		// https://regex101.com/r/ACN0rE/2
+		$mustache_regex = '/({{\s*)(\w*?\|?\w*)(\s*}})/';
 
 		// Get matches for {% include "path/c-element.twig" with data %}
 		// https://regex101.com/r/ns5kBR/2

--- a/packages/twig-to-php-parser/lib/twig-to-php-parser.php
+++ b/packages/twig-to-php-parser/lib/twig-to-php-parser.php
@@ -119,11 +119,19 @@ function twig_to_php_parser( $patterns_dir_path, $template_dir_path ) {
 		foreach ( $mustache_matches[0] as $key => $match ) {
 
 			$variable_name = $mustache_matches[2][ $count ];
+
 			$is_attr       = strpos( $match, 'class' ) || strpos( $match, 'name' ) || strpos( $match, 'attr' );
 			$is_url        = strpos( $match, 'url' );
 			$is_text       = strpos( $match, 'text' );
 			$is_data_attr  = strpos( $match, 'attributes' );
 			$is_markup     = strpos( $match, 'markup' );
+			$has_filter    = strpos( $match, '|' );
+
+			// Remove the Twig filter from the variable name
+			if ( $has_filter ) {
+				$string_parts = explode( '|', $variable_name );
+				$variable_name = $string_parts[0];
+			}
 
 			if ( ! empty( $is_url ) ) {
 				$mustache_replacements[ $count ] = '<?php echo esc_url( $' . $variable_name . ' ?? \'\' ); ?>';


### PR DESCRIPTION
This is a cool one! Trim off the `|filter` from a variable name, so we can use Twig filters in pattern templates to help with demo content.