### PR TITLE
Enable shadow tokens

### DIFF
--- a/packages/larva-scss/dist/_tokens.scss
+++ b/packages/larva-scss/dist/_tokens.scss
@@ -2,5 +2,5 @@
 @import '../lib/tokens/typography';
 @import '../lib/tokens/sizing';
 @import '../lib/tokens/z-index';
-// @import '../lib/tokens/shadows';
+@import '../lib/tokens/shadows';
 @import '../lib/tokens/transition';

--- a/packages/larva-scss/lib/tokens/_shadows.scss
+++ b/packages/larva-scss/lib/tokens/_shadows.scss
@@ -1,11 +1,6 @@
-// Shadows
-//
-// Style Guide: Settings.Shadows
-
 // stylelint-disable unit-blacklist
 $shadow-light:   0 2px 4px 0 rgba(0,0,0,0.08); // Used on sticky menu.
 $shadow-medium:  0 -2px 9px 0 rgba(0,0,0,0.1);
 $shadow-dark:    0 14px 8px -8px rgba(0,0,0,0.18); // Button.
 $shadow-inset:   inset 0 3px 6px 0 rgba(0,0,0,0.5); // Input inset.
-$shadow-green: inset 0 5px 0 0 map-get( $semantic-color-list, green ), 0 2px 4px 0 rgba(0,0,0,0.15);
 // stylelint-enable unit-blacklist


### PR DESCRIPTION
Note these are "unofficial" tokens as map-less Sass variables – eventually they can be added to larva-tokens. For now, this will be fine.