### PR TITLE
o-icon-button: Search configuration

### DIFF
--- a/packages/larva-patterns/objects/o-icon-button/README.md
+++ b/packages/larva-patterns/objects/o-icon-button/README.md
@@ -1,3 +1,7 @@
 # o-icon-button
 
 The Icon button is comprised of c_icon and c_span. While c_icon and c_span both support URLs, any URL for o-icon-button should be passed using o_icon_button_url. In this case, it will render an anchor tag instead of a button tag.
+
+## Available configurations:
+
+* `o-icon-button.search` – Contains search icon from `c-icon` and no text.

--- a/packages/larva-patterns/objects/o-icon-button/o-icon-button.prototype.js
+++ b/packages/larva-patterns/objects/o-icon-button/o-icon-button.prototype.js
@@ -1,8 +1,10 @@
+const clonedeep = require( 'lodash.clonedeep' );
+
 const c_span_prototype = require( '../../components/c-span/c-span.prototype' );
 const c_icon_prototype = require( '../../components/c-icon/c-icon.prototype' );
 
-const c_span = Object.assign( {}, c_span_prototype );
-const c_icon = Object.assign( {}, c_icon_prototype );
+const c_span = clonedeep( c_span_prototype );
+const c_icon = clonedeep( c_icon_prototype );
 
 c_icon.c_icon_name = 'hamburger';
 c_icon.c_icon_url = false;

--- a/packages/larva-patterns/objects/o-icon-button/o-icon-button.search.js
+++ b/packages/larva-patterns/objects/o-icon-button/o-icon-button.search.js
@@ -1,0 +1,8 @@
+const clonedeep = require( 'lodash.clonedeep' );
+const o_icon_button_prototype = require( './o-icon-button.prototype' );
+const o_icon_button_search = clonedeep( o_icon_button_prototype );
+
+o_icon_button_search.c_icon.c_icon_name = 'search';
+o_icon_button_search.c_span = false;
+
+module.exports = o_icon_button_search;

--- a/packages/larva-patterns/package.json
+++ b/packages/larva-patterns/package.json
@@ -23,7 +23,8 @@
     "@penskemediacorp/larva": "^2.9.0-alpha.0",
     "@penskemediacorp/larva-css": "^2.9.0-alpha.0",
     "@penskemediacorp/larva-js": "^2.9.0-alpha.0",
-    "@penskemediacorp/larva-svg": "^2.8.2-alpha.0"
+    "@penskemediacorp/larva-svg": "^2.8.2-alpha.0",
+    "lodash.clonedeep": "^4.5.0"
   },
   "devDependencies": {
     "stylelint": "^10.1.0"


### PR DESCRIPTION
- Add `o-icon-button.search`
- Add lodash.clonedeep to deep clone pattern objects – eventually will need to refactor existing patterns to include this and other, future helper methods, but for now, this will be used as needed. 