### PR TITLE
o-figure: Refactor and split into components

### DIFF
--- a/packages/larva-css/build/css/generic.common.inline.css
+++ b/packages/larva-css/build/css/generic.common.inline.css
@@ -1,4 +1,4 @@
-*{box-sizing:border-box}img{max-width:100%;height:auto}figure{margin:0}[hidden]{display:none;width:0;height:0}#icon-sprite{display:none}svg{fill:currentColor}
+*{box-sizing:border-box}img{max-width:100%;height:auto}figure{margin:0}[hidden]{display:none;width:0;height:0}#icon-sprite{display:none}svg{fill:currentColor}cite{font-style:normal}
 
 ::placeholder{color:#e6e6e6}button{padding-left:0;padding-right:0}
 

--- a/packages/larva-css/src/01-generic/elements.common.inline.scss
+++ b/packages/larva-css/src/01-generic/elements.common.inline.scss
@@ -25,3 +25,7 @@ figure {
 svg {
 	fill: currentColor;
 }
+
+cite {
+	font-style: normal;
+}

--- a/packages/larva-patterns/components/c-figcaption/c-figcaption.prototype.js
+++ b/packages/larva-patterns/components/c-figcaption/c-figcaption.prototype.js
@@ -1,0 +1,7 @@
+module.exports = {
+	c_figcaption_classes: '',
+	c_figcaption_caption_markup: 'Protest art hangs at Hong Kong <em>International Airport</em>.',
+	c_figcaption_caption_classes: '',
+	c_figcaption_credit_text: 'Courtesty Wong Ka Ying',
+	c_figcaption_credit_classes: ''
+}

--- a/packages/larva-patterns/components/c-figcaption/c-figcaption.twig
+++ b/packages/larva-patterns/components/c-figcaption/c-figcaption.twig
@@ -1,0 +1,8 @@
+<figcaption class="c-figcaption {{ c_figcaption_classes }}">
+	{% if c_figcaption_caption_markup %}
+		<span class="{{ c_figcaption_caption_classes }}">{{ c_figcaption_caption_markup|raw }}</span>
+	{% endif %}
+	{% if c_figcaption_credit_text %}
+		<cite class="{{ c_figcaption_credit_classes }}">{{ c_figcaption_credit_text }}</cite>
+	{% endif %}
+</figcaption>

--- a/packages/larva-patterns/components/c-heading/c-heading.prototype.js
+++ b/packages/larva-patterns/components/c-heading/c-heading.prototype.js
@@ -1,5 +1,5 @@
 module.exports = {
-	"c_heading_text": "Section Heading",
-	"c_heading_url": "",
-	"c_heading_link_classes": ""
+	c_heading_text: 'Heading',
+	c_heading_url: '',
+	c_heading_link_classes: ''
 }

--- a/packages/larva-patterns/components/c-lazy-image/c-lazy-image.prototype.js
+++ b/packages/larva-patterns/components/c-lazy-image/c-lazy-image.prototype.js
@@ -1,11 +1,11 @@
 module.exports = {
-	c_lazy_image_link_url: '',
+	c_lazy_image_link_url: false,
 	c_lazy_image_link_classes: 'lrv-a-unstyle-link',
 	c_lazy_image_crop_class: 'lrv-a-crop-16x9',
 	c_lazy_image_crop_style_attr: false,
 	c_lazy_image_alt_attr: 'Lazy loaded image',
 	c_lazy_image_src_url: 'https://farm5.staticflickr.com/4078/5441060528_31db7838ba_z.jpg',
-	c_lazy_image_placeholder_src_url: 'data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==',
+	c_lazy_image_placeholder_url: 'data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==',
 	c_lazy_image_lazy_srcset_url: 'https://farm5.staticflickr.com/4078/5441060528_31db7838ba_m.jpg 240w,https://farm5.staticflickr.com/4078/5441060528_31db7838ba_n.jpg 320w,https://farm5.staticflickr.com/4078/5441060528_31db7838ba.jpg 500w,https://farm5.staticflickr.com/4078/5441060528_31db7838ba_z.jpg 640w,https://farm5.staticflickr.com/4078/5441060528_31db7838ba_b.jpg 1024w',
 	c_lazy_image_lazy_sizes_attr: 'auto',
 	c_lazy_image_classes: 'lrv-u-background-color-grey-lightest lrv-u-width-100p lrv-u-display-block lrv-u-height-auto',

--- a/packages/larva-patterns/components/c-lazy-image/c-lazy-image.prototype.js
+++ b/packages/larva-patterns/components/c-lazy-image/c-lazy-image.prototype.js
@@ -1,4 +1,5 @@
 module.exports = {
+	c_lazy_image_classes: '',
 	c_lazy_image_link_url: false,
 	c_lazy_image_link_classes: 'lrv-a-unstyle-link',
 	c_lazy_image_crop_class: 'lrv-a-crop-16x9',
@@ -8,7 +9,7 @@ module.exports = {
 	c_lazy_image_placeholder_url: 'data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==',
 	c_lazy_image_lazy_srcset_url: 'https://farm5.staticflickr.com/4078/5441060528_31db7838ba_m.jpg 240w,https://farm5.staticflickr.com/4078/5441060528_31db7838ba_n.jpg 320w,https://farm5.staticflickr.com/4078/5441060528_31db7838ba.jpg 500w,https://farm5.staticflickr.com/4078/5441060528_31db7838ba_z.jpg 640w,https://farm5.staticflickr.com/4078/5441060528_31db7838ba_b.jpg 1024w',
 	c_lazy_image_lazy_sizes_attr: 'auto',
-	c_lazy_image_classes: 'lrv-u-background-color-grey-lightest lrv-u-width-100p lrv-u-display-block lrv-u-height-auto',
+	c_lazy_image_img_classes: 'lrv-u-background-color-grey-lightest lrv-u-width-100p lrv-u-display-block lrv-u-height-auto',
 	c_lazy_image_height_attr: '',
 	c_lazy_image_width_attr: ''
 }

--- a/packages/larva-patterns/components/c-lazy-image/c-lazy-image.prototype.js
+++ b/packages/larva-patterns/components/c-lazy-image/c-lazy-image.prototype.js
@@ -1,0 +1,14 @@
+module.exports = {
+	c_lazy_image_link_url: '',
+	c_lazy_image_link_classes: 'lrv-a-unstyle-link',
+	c_lazy_image_crop_class: 'lrv-a-crop-16x9',
+	c_lazy_image_crop_style_attr: false,
+	c_lazy_image_alt_attr: 'Lazy loaded image',
+	c_lazy_image_src_url: 'https://farm5.staticflickr.com/4078/5441060528_31db7838ba_z.jpg',
+	c_lazy_image_placeholder_src_url: 'data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==',
+	c_lazy_image_lazy_srcset_url: 'https://farm5.staticflickr.com/4078/5441060528_31db7838ba_m.jpg 240w,https://farm5.staticflickr.com/4078/5441060528_31db7838ba_n.jpg 320w,https://farm5.staticflickr.com/4078/5441060528_31db7838ba.jpg 500w,https://farm5.staticflickr.com/4078/5441060528_31db7838ba_z.jpg 640w,https://farm5.staticflickr.com/4078/5441060528_31db7838ba_b.jpg 1024w',
+	c_lazy_image_lazy_sizes_attr: 'auto',
+	c_lazy_image_classes: 'lrv-u-background-color-grey-lightest lrv-u-width-100p lrv-u-display-block lrv-u-height-auto',
+	c_lazy_image_height_attr: '',
+	c_lazy_image_width_attr: ''
+}

--- a/packages/larva-patterns/components/c-lazy-image/c-lazy-image.prototype.js
+++ b/packages/larva-patterns/components/c-lazy-image/c-lazy-image.prototype.js
@@ -7,8 +7,8 @@ module.exports = {
 	c_lazy_image_alt_attr: 'Lazy loaded image',
 	c_lazy_image_src_url: 'https://farm5.staticflickr.com/4078/5441060528_31db7838ba_z.jpg',
 	c_lazy_image_placeholder_url: 'data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==',
-	c_lazy_image_lazy_srcset_url: 'https://farm5.staticflickr.com/4078/5441060528_31db7838ba_m.jpg 240w,https://farm5.staticflickr.com/4078/5441060528_31db7838ba_n.jpg 320w,https://farm5.staticflickr.com/4078/5441060528_31db7838ba.jpg 500w,https://farm5.staticflickr.com/4078/5441060528_31db7838ba_z.jpg 640w,https://farm5.staticflickr.com/4078/5441060528_31db7838ba_b.jpg 1024w',
-	c_lazy_image_lazy_sizes_attr: 'auto',
+	c_lazy_image_srcset_url: 'https://farm5.staticflickr.com/4078/5441060528_31db7838ba_m.jpg 240w,https://farm5.staticflickr.com/4078/5441060528_31db7838ba_n.jpg 320w,https://farm5.staticflickr.com/4078/5441060528_31db7838ba.jpg 500w,https://farm5.staticflickr.com/4078/5441060528_31db7838ba_z.jpg 640w,https://farm5.staticflickr.com/4078/5441060528_31db7838ba_b.jpg 1024w',
+	c_lazy_image_sizes_attr: 'auto',
 	c_lazy_image_img_classes: 'lrv-u-background-color-grey-lightest lrv-u-width-100p lrv-u-display-block lrv-u-height-auto',
 	c_lazy_image_height_attr: '',
 	c_lazy_image_width_attr: ''

--- a/packages/larva-patterns/components/c-lazy-image/c-lazy-image.twig
+++ b/packages/larva-patterns/components/c-lazy-image/c-lazy-image.twig
@@ -1,5 +1,5 @@
 <div class="c-lazy-image {{ c_lazy_image_classes }}">
-	{% if c_lazy_image_permalink_url %}
+	{% if c_lazy_image_link_url %}
 		<a href="{{ c_lazy_image_link_url }}" class="c-lazy-image__link {{ c_lazy_image_link_classes }}">
 	{% endif %}
 
@@ -10,8 +10,8 @@
 	{% if c_lazy_image_markup %}
 		{{ c_lazy_image_markup }}
 	{% else %}
-		<img class="c-lazy-image__img {{ c_lazy_image_img_classes }}" src="{{ c_lazy_image_placeholder_url }}" data-lazy-src="{{ c_lazy_image_src_url }}" alt="{{ c_lazy_image_alt_attr }}" data-lazy-srcset="{{ c_lazy_image_lazy_srcset_attr }}" data-lazy-sizes="{{ c_lazy_image_lazy_sizes_attr }}" height="{{ c_lazy_image_height_attr }}" width="{{ c_lazy_image_width_attr }}">
-		<noscript><img class="{{ c_lazy_image_classes }}" src="{{ c_lazy_image_url }}" alt="{{ c_lazy_image_alt_attr }}" srcset="{{ c_lazy_image_lazy_srcset_attr }}" sizes="{{ c_lazy_image_lazy_sizes_attr }}" height="{{ c_lazy_image_height_attr }}" width="{{ c_lazy_image_width_attr }}"></noscript>
+		<img class="c-lazy-image__img {{ c_lazy_image_img_classes }}" src="{{ c_lazy_image_placeholder_url }}" data-lazy-src="{{ c_lazy_image_src_url }}" alt="{{ c_lazy_image_alt_attr }}" data-lazy-srcset="{{ c_lazy_image_srcset_attr }}" data-lazy-sizes="{{ c_lazy_image_sizes_attr }}" height="{{ c_lazy_image_height_attr }}" width="{{ c_lazy_image_width_attr }}">
+		<noscript><img class="{{ c_lazy_image_classes }}" src="{{ c_lazy_image_url }}" alt="{{ c_lazy_image_alt_attr }}" srcset="{{ c_lazy_image_srcset_attr }}" sizes="{{ c_lazy_image_sizes_attr }}" height="{{ c_lazy_image_height_attr }}" width="{{ c_lazy_image_width_attr }}"></noscript>
 	{% endif %}
 
 	{% if c_lazy_image_crop_class %}

--- a/packages/larva-patterns/components/c-lazy-image/c-lazy-image.twig
+++ b/packages/larva-patterns/components/c-lazy-image/c-lazy-image.twig
@@ -1,22 +1,24 @@
-{% if c_lazy_image_permalink_url %}
-	<a href="{{ c_lazy_image_link_url }}" class="c-lazy-image__link {{ c_lazy_image_link_classes }}">
-{% endif %}
+<div class="c-lazy-image {{ c_lazy_image_classes }}">
+	{% if c_lazy_image_permalink_url %}
+		<a href="{{ c_lazy_image_link_url }}" class="c-lazy-image__link {{ c_lazy_image_link_classes }}">
+	{% endif %}
 
-{% if c_lazy_image_crop_class %}
-	<div class="c-lazy-image {{ c_lazy_image_crop_class }}" style="{{ c_lazy_image_crop_style_attr }}">
-{% endif %}
+	{% if c_lazy_image_crop_class %}
+		<div class="{{ c_lazy_image_crop_class }}" style="{{ c_lazy_image_crop_style_attr }}">
+	{% endif %}
 
-{% if c_lazy_image_markup %}
-	{{ c_lazy_image_markup }}
-{% else %}
-	<img class="c-lazy-image__img {{ c_lazy_image_classes }}" src="{{ c_lazy_image_placeholder_url }}" data-lazy-src="{{ c_lazy_image_src_url }}" alt="{{ c_lazy_image_alt_attr }}" data-lazy-srcset="{{ c_lazy_image_lazy_srcset_attr }}" data-lazy-sizes="{{ c_lazy_image_lazy_sizes_attr }}" height="{{ c_lazy_image_height_attr }}" width="{{ c_lazy_image_width_attr }}">
-	<noscript><img class="{{ c_lazy_image_classes }}" src="{{ c_lazy_image_url }}" alt="{{ c_lazy_image_alt_attr }}" srcset="{{ c_lazy_image_lazy_srcset_attr }}" sizes="{{ c_lazy_image_lazy_sizes_attr }}" height="{{ c_lazy_image_height_attr }}" width="{{ c_lazy_image_width_attr }}"></noscript>
-{% endif %}
+	{% if c_lazy_image_markup %}
+		{{ c_lazy_image_markup }}
+	{% else %}
+		<img class="c-lazy-image__img {{ c_lazy_image_img_classes }}" src="{{ c_lazy_image_placeholder_url }}" data-lazy-src="{{ c_lazy_image_src_url }}" alt="{{ c_lazy_image_alt_attr }}" data-lazy-srcset="{{ c_lazy_image_lazy_srcset_attr }}" data-lazy-sizes="{{ c_lazy_image_lazy_sizes_attr }}" height="{{ c_lazy_image_height_attr }}" width="{{ c_lazy_image_width_attr }}">
+		<noscript><img class="{{ c_lazy_image_classes }}" src="{{ c_lazy_image_url }}" alt="{{ c_lazy_image_alt_attr }}" srcset="{{ c_lazy_image_lazy_srcset_attr }}" sizes="{{ c_lazy_image_lazy_sizes_attr }}" height="{{ c_lazy_image_height_attr }}" width="{{ c_lazy_image_width_attr }}"></noscript>
+	{% endif %}
 
-{% if c_lazy_image_crop_class %}
-	</div>
-{% endif %}
+	{% if c_lazy_image_crop_class %}
+		</div>
+	{% endif %}
 
-{% if c_lazy_image_link_url %}
-	</a>
-{% endif %}
+	{% if c_lazy_image_link_url %}
+		</a>
+	{% endif %}
+</div>

--- a/packages/larva-patterns/components/c-lazy-image/c-lazy-image.twig
+++ b/packages/larva-patterns/components/c-lazy-image/c-lazy-image.twig
@@ -1,0 +1,22 @@
+{% if c_lazy_image_permalink_url %}
+	<a href="{{ c_lazy_image_link_url }}" class="c-lazy-image__link {{ c_lazy_image_link_classes }}">
+{% endif %}
+
+{% if c_lazy_image_crop_class %}
+	<div class="c-lazy-image {{ c_lazy_image_crop_class }}" style="{{ c_lazy_image_crop_style_attr }}">
+{% endif %}
+
+{% if c_lazy_image_markup %}
+	{{ c_lazy_image_markup }}
+{% else %}
+	<img class="c-lazy-image__img {{ c_lazy_image_classes }}" src="{{ c_lazy_image_placeholder_url }}" data-lazy-src="{{ c_lazy_image_src_url }}" alt="{{ c_lazy_image_alt_attr }}" data-lazy-srcset="{{ c_lazy_image_lazy_srcset_attr }}" data-lazy-sizes="{{ c_lazy_image_lazy_sizes_attr }}" height="{{ c_lazy_image_height_attr }}" width="{{ c_lazy_image_width_attr }}">
+	<noscript><img class="{{ c_lazy_image_classes }}" src="{{ c_lazy_image_url }}" alt="{{ c_lazy_image_alt_attr }}" srcset="{{ c_lazy_image_lazy_srcset_attr }}" sizes="{{ c_lazy_image_lazy_sizes_attr }}" height="{{ c_lazy_image_height_attr }}" width="{{ c_lazy_image_width_attr }}"></noscript>
+{% endif %}
+
+{% if c_lazy_image_crop_class %}
+	</div>
+{% endif %}
+
+{% if c_lazy_image_link_url %}
+	</a>
+{% endif %}

--- a/packages/larva-patterns/components/c-lazy-image/c-lazy-image.twig
+++ b/packages/larva-patterns/components/c-lazy-image/c-lazy-image.twig
@@ -11,7 +11,7 @@
 		{{ c_lazy_image_markup }}
 	{% else %}
 		<img class="c-lazy-image__img {{ c_lazy_image_img_classes }}" src="{{ c_lazy_image_placeholder_url }}" data-lazy-src="{{ c_lazy_image_src_url }}" alt="{{ c_lazy_image_alt_attr }}" data-lazy-srcset="{{ c_lazy_image_srcset_attr }}" data-lazy-sizes="{{ c_lazy_image_sizes_attr }}" height="{{ c_lazy_image_height_attr }}" width="{{ c_lazy_image_width_attr }}">
-		<noscript><img class="{{ c_lazy_image_classes }}" src="{{ c_lazy_image_url }}" alt="{{ c_lazy_image_alt_attr }}" srcset="{{ c_lazy_image_srcset_attr }}" sizes="{{ c_lazy_image_sizes_attr }}" height="{{ c_lazy_image_height_attr }}" width="{{ c_lazy_image_width_attr }}"></noscript>
+		<noscript><img class="{{ c_lazy_image_classes }}" src="{{ c_lazy_image_src_url }}" alt="{{ c_lazy_image_alt_attr }}" srcset="{{ c_lazy_image_srcset_attr }}" sizes="{{ c_lazy_image_sizes_attr }}" height="{{ c_lazy_image_height_attr }}" width="{{ c_lazy_image_width_attr }}"></noscript>
 	{% endif %}
 
 	{% if c_lazy_image_crop_class %}

--- a/packages/larva-patterns/objects/o-figure/o-figure.prototype.js
+++ b/packages/larva-patterns/objects/o-figure/o-figure.prototype.js
@@ -3,19 +3,13 @@ const clonedeep = require( 'lodash.clonedeep' );
 const c_figcaption_prototype = require( '../../components/c-figcaption/c-figcaption.prototype' );
 const c_figcaption = clonedeep( c_figcaption_prototype );
 
+const c_lazy_image_prototype = require( '../../components/c-lazy-image/c-lazy-image.prototype' );
+const c_lazy_image = clonedeep( c_lazy_image_prototype );
+
 module.exports = {
 	c_figcaption: c_figcaption,
-	o_figure_permalink_url: false,
+	c_lazy_image: c_lazy_image,
+	o_figure_link_url: false,
 	o_figure_classes: '',
 	o_figure_link_classes: 'lrv-a-unstyle-link ',
-	o_figure_crop_class: 'lrv-a-crop-16x9',
-	o_figure_crop_style_attr: false,
-	o_figure_alt_attr: 'Thumbnail image',
-	o_figure_image_url: 'https://farm5.staticflickr.com/4078/5441060528_31db7838ba_z.jpg',
-	o_figure_placeholder_image_url: 'data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==',
-	o_figure_lazy_srcset_url: 'https://farm5.staticflickr.com/4078/5441060528_31db7838ba_m.jpg 240w,https://farm5.staticflickr.com/4078/5441060528_31db7838ba_n.jpg 320w,https://farm5.staticflickr.com/4078/5441060528_31db7838ba.jpg 500w,https://farm5.staticflickr.com/4078/5441060528_31db7838ba_z.jpg 640w,https://farm5.staticflickr.com/4078/5441060528_31db7838ba_b.jpg 1024w',
-	o_figure_lazy_sizes_attr: 'auto',
-	o_figure_image_classes: 'lrv-u-background-color-grey-lightest lrv-u-width-100p lrv-u-display-block lrv-u-height-auto',
-	o_figure_image_height_attr: '',
-	o_figure_image_width_attr: '',
 }

--- a/packages/larva-patterns/objects/o-figure/o-figure.prototype.js
+++ b/packages/larva-patterns/objects/o-figure/o-figure.prototype.js
@@ -1,5 +1,10 @@
+const clonedeep = require( 'lodash.clonedeep' );
+
+const c_figcaption_prototype = require( '../../components/c-figcaption/c-figcaption.prototype' );
+const c_figcaption = clonedeep( c_figcaption_prototype );
+
 module.exports = {
-	c_button: false,
+	c_figcaption: c_figcaption,
 	o_figure_permalink_url: false,
 	o_figure_classes: '',
 	o_figure_link_classes: 'lrv-a-unstyle-link ',
@@ -11,9 +16,6 @@ module.exports = {
 	o_figure_lazy_srcset_url: 'https://farm5.staticflickr.com/4078/5441060528_31db7838ba_m.jpg 240w,https://farm5.staticflickr.com/4078/5441060528_31db7838ba_n.jpg 320w,https://farm5.staticflickr.com/4078/5441060528_31db7838ba.jpg 500w,https://farm5.staticflickr.com/4078/5441060528_31db7838ba_z.jpg 640w,https://farm5.staticflickr.com/4078/5441060528_31db7838ba_b.jpg 1024w',
 	o_figure_lazy_sizes_attr: 'auto',
 	o_figure_image_classes: 'lrv-u-background-color-grey-lightest lrv-u-width-100p lrv-u-display-block lrv-u-height-auto',
-	o_figure_caption_markup: false,
-	o_figure_credit_text: false,
-	o_figure_screen_reader_text: 'Image',
 	o_figure_image_height_attr: '',
 	o_figure_image_width_attr: '',
 }

--- a/packages/larva-patterns/objects/o-figure/o-figure.prototype.js
+++ b/packages/larva-patterns/objects/o-figure/o-figure.prototype.js
@@ -6,12 +6,14 @@ module.exports = {
 	o_figure_crop_class: 'lrv-a-crop-16x9',
 	o_figure_crop_style_attr: false,
 	o_figure_alt_attr: 'Thumbnail image',
+	o_figure_image_url: 'https://farm5.staticflickr.com/4078/5441060528_31db7838ba_z.jpg',
 	o_figure_placeholder_image_url: 'data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==',
 	o_figure_lazy_srcset_url: 'https://farm5.staticflickr.com/4078/5441060528_31db7838ba_m.jpg 240w,https://farm5.staticflickr.com/4078/5441060528_31db7838ba_n.jpg 320w,https://farm5.staticflickr.com/4078/5441060528_31db7838ba.jpg 500w,https://farm5.staticflickr.com/4078/5441060528_31db7838ba_z.jpg 640w,https://farm5.staticflickr.com/4078/5441060528_31db7838ba_b.jpg 1024w',
 	o_figure_lazy_sizes_attr: 'auto',
-	o_figure_image_url: 'https://farm5.staticflickr.com/4078/5441060528_31db7838ba_z.jpg',
 	o_figure_image_classes: 'lrv-u-background-color-grey-lightest lrv-u-width-100p lrv-u-display-block lrv-u-height-auto',
 	o_figure_caption_markup: false,
 	o_figure_credit_text: false,
-	o_figure_screen_reader_text: 'Image'
+	o_figure_screen_reader_text: 'Image',
+	o_figure_image_height_attr: '',
+	o_figure_image_width_attr: '',
 }

--- a/packages/larva-patterns/objects/o-figure/o-figure.twig
+++ b/packages/larva-patterns/objects/o-figure/o-figure.twig
@@ -1,30 +1,11 @@
-{% if o_figure_permalink_url %}
-	<a href="{{ o_figure_permalink_url }}" class="o-figure__link {{ o_figure_link_classes }}">
+{% if o_figure_link_url %}
+	<a href="{{ o_figure_link_url }}" class="o-figure__link {{ o_figure_link_classes }}">
 {% endif %}
 
 <figure class="o-figure {{ modifier_class }} {{ o_figure_classes }} lrv-u-max-width-100p" style="{{ o_figure_width_attr }}">
 
-	{% if o_figure_crop_class %}
-		<div class="{{ o_figure_crop_class }}">
-	{% endif %}
-
-	{% if o_figure_crop_style_attr %}
-		<div class="lrv-a-crop-4x3" style="{{ o_figure_crop_style_attr }}">
-	{% endif %}
-
-	{% if o_figure_image_markup %}
-		{{ o_figure_image_markup }}
-	{% else %}
-		<img class="o-figure__image {{ o_figure_image_classes }}" src="{{ o_figure_placeholder_image_url }}" data-lazy-src="{{ o_figure_image_url }}" alt="{{ o_figure_alt_attr }}" data-lazy-srcset="{{ o_figure_lazy_srcset_attr }}" data-lazy-sizes="{{ o_figure_lazy_sizes_attr }}" height="{{ o_figure_image_height_attr }}" width="{{ o_figure_image_width_attr }}">
-		<noscript><img class="o-figure__image {{ o_figure_image_classes }}" src="{{ o_figure_image_url }}" alt="{{ o_figure_alt_attr }}" srcset="{{ o_figure_lazy_srcset_attr }}" sizes="{{ o_figure_lazy_sizes_attr }}" height="{{ o_figure_image_height_attr }}" width="{{ o_figure_image_width_attr }}"></noscript>
-	{% endif %}
-
-	{% if o_figure_crop_class %}
-		</div>
-	{% endif %}
-
-	{% if o_figure_crop_style_attr %}
-		</div>
+	{% if c_lazy_image %}
+		{% include "@larva/components/c-lazy-image/c-lazy-image.twig" with c_lazy_image %}
 	{% endif %}
 
 	{% if c_figcaption %}
@@ -33,6 +14,6 @@
 
 </figure>
 
-{% if o_figure_permalink_url %}
+{% if o_figure_link_url %}
 	</a>
 {% endif %}

--- a/packages/larva-patterns/objects/o-figure/o-figure.twig
+++ b/packages/larva-patterns/objects/o-figure/o-figure.twig
@@ -19,10 +19,6 @@
 		<noscript><img class="o-figure__image {{ o_figure_image_classes }}" src="{{ o_figure_image_url }}" alt="{{ o_figure_alt_attr }}" srcset="{{ o_figure_lazy_srcset_attr }}" sizes="{{ o_figure_lazy_sizes_attr }}" height="{{ o_figure_image_height_attr }}" width="{{ o_figure_image_width_attr }}"></noscript>
 	{% endif %}
 
-	{% if c_button %}
-		{% include "@larva/components/c-button/c-button.twig" with c_button %}
-	{% endif %}
-
 	{% if o_figure_crop_class %}
 		</div>
 	{% endif %}

--- a/packages/larva-patterns/objects/o-figure/o-figure.twig
+++ b/packages/larva-patterns/objects/o-figure/o-figure.twig
@@ -18,7 +18,8 @@
 	{% if o_figure_image_markup %}
 		{{ o_figure_image_markup }}
 	{% else %}
-		<img class="o-figure__image {{ o_figure_image_classes }}" src="{{ o_figure_placeholder_image_url }}" data-lazy-src="{{ o_figure_image_url }}" alt="{{ o_figure_alt_attr }}" data-lazy-srcset="{{ o_figure_lazy_srcset_attr }}" data-lazy-sizes="{{ o_figure_lazy_sizes_attr }}">
+		<img class="o-figure__image {{ o_figure_image_classes }}" src="{{ o_figure_placeholder_image_url }}" data-lazy-src="{{ o_figure_image_url }}" alt="{{ o_figure_alt_attr }}" data-lazy-srcset="{{ o_figure_lazy_srcset_attr }}" data-lazy-sizes="{{ o_figure_lazy_sizes_attr }}" height="{{ o_figure_image_height_attr }}" width="{{ o_figure_image_width_attr }}">
+		<noscript><img class="o-figure__image {{ o_figure_image_classes }}" src="{{ o_figure_image_url }}" alt="{{ o_figure_alt_attr }}" srcset="{{ o_figure_lazy_srcset_attr }}" sizes="{{ o_figure_lazy_sizes_attr }}" height="{{ o_figure_image_height_attr }}" width="{{ o_figure_image_width_attr }}"></noscript>
 	{% endif %}
 
 	{% if c_button %}

--- a/packages/larva-patterns/objects/o-figure/o-figure.twig
+++ b/packages/larva-patterns/objects/o-figure/o-figure.twig
@@ -2,17 +2,14 @@
 	<a href="{{ o_figure_permalink_url }}" class="o-figure__link {{ o_figure_link_classes }}">
 {% endif %}
 
-
 <figure class="o-figure {{ modifier_class }} {{ o_figure_classes }} lrv-u-max-width-100p" style="{{ o_figure_width_attr }}">
-
-	{% if o_figure_screen_reader_text %}
-		<span class="lrv-a-screen-reader-only">{{ o_figure_screen_reader_text }}</span>
-	{% endif %}
 
 	{% if o_figure_crop_class %}
 		<div class="{{ o_figure_crop_class }}">
-	{% else %}
-		<div style="{{ o_figure_crop_style_attr }}">
+	{% endif %}
+
+	{% if o_figure_crop_style_attr %}
+		<div class="lrv-a-crop-4x3" style="{{ o_figure_crop_style_attr }}">
 	{% endif %}
 
 	{% if o_figure_image_markup %}
@@ -30,15 +27,12 @@
 		</div>
 	{% endif %}
 
-	{% if o_figure_credit_text %}
-		<figcaption class="o-figure__caption {{ o_figure_figcaption_classes }}">
-			{% if o_figure_caption_markup %}
-				<span class="{{ o_figure_caption_classes }}">{{ o_figure_caption_markup }}</span>
-			{% endif %}
-			{% if o_figure_credit_text %}
-				<span class="{{ o_figure_credit_classes }}">{{ o_figure_credit_text }}</span>
-			{% endif %}
-		</figcaption>
+	{% if o_figure_crop_style_attr %}
+		</div>
+	{% endif %}
+
+	{% if c_figcaption %}
+		{% include "@larva/components/c-figcaption/c-figcaption.twig" with c_figcaption %}
 	{% endif %}
 
 </figure>

--- a/packages/larva-patterns/objects/o-header/o-header.prototype.js
+++ b/packages/larva-patterns/objects/o-header/o-header.prototype.js
@@ -1,12 +1,17 @@
+const clonedeep = require( 'lodash.clonedeep' );
+
+const c_heading_prototype = require( '../../components/c-heading/c-heading.prototype' );
+const c_heading = clonedeep( c_heading_prototype );
+
+const c_button_prototype = require( '../../components/c-button/c-button.prototype' );
+const c_button = clonedeep( c_button_prototype );
+
+c_button.c_button_classes = 'c-button--plain lrv-u-font-size-12 lrv-u-text-transform-uppercase lrv-a-icon-after lrv-a-icon-arrow-right lrv-u-margin-l-auto';
+c_button.c_button_text = 'Link';
+c_button.c_button_url = '#';
+
 module.exports = {
-	"o_heading_classes": "u-flex u-align-items-center lrv-u-background-color-black lrv-u-padding-a-1",
-	"c_heading": {
-		"c_heading_classes": "lrv-u-color-white",
-		"c_heading_text": "Section Heading"
-	},
-	"c_button": {
-		"modifier_class": "c-button--plain lrv-u-font-size-12 lrv-u-color-white lrv-u-text-transform-uppercase lrv-a-icon-after lrv-a-icon-arrow-right u-margin-l-auto",
-		"c_button_url": "#",
-		"c_button_text": "Link"
-	}
+	o_heading_classes: 'lrv-u-flex lrv-u-align-items-center lrv-u-padding-a-1',
+	c_heading: c_heading,
+	c_button: c_button
 };

--- a/packages/larva-patterns/objects/o-header/o-header.twig
+++ b/packages/larva-patterns/objects/o-header/o-header.twig
@@ -1,8 +1,9 @@
-<header class="o-heading {{ modifier_class }} {{ o_heading_classes }}">
+<header class="o-header {{ modifier_class }} {{ o_heading_classes }}">
 	{% if c_heading %}
 		{% include "@larva/components/c-heading/c-heading.twig" with c_heading %}
 	{% endif %}
 
+	{# TODO: replace with c-logo when it is moved to Larva #}
 	{% if o_figure %}
 		{% include "@larva/objects/o-figure/o-figure.twig" with o_figure %}
 	{% endif %}

--- a/packages/larva-patterns/objects/o-sponsored-by/o-sponsored-by.prototype.js
+++ b/packages/larva-patterns/objects/o-sponsored-by/o-sponsored-by.prototype.js
@@ -4,7 +4,7 @@ module.exports = {
 	"o_sponsored_by_text": "Sponsored by",
 	"o_figure": {
 		"o_figure_classes": "u-width-50",
-		"o_figure_permalink_url": "#",
+		"o_figure_link_url": "#",
 		"o_figure_alt_text": "Thumbnail image",
 		"o_figure_image_url": "https://picsum.photos/57/11"
 	}

--- a/packages/larva-patterns/objects/o-sponsored-by/o-sponsored-by.prototype.js
+++ b/packages/larva-patterns/objects/o-sponsored-by/o-sponsored-by.prototype.js
@@ -1,11 +1,12 @@
+const clonedeep = require( 'lodash.clonedeep' );
+const c_lazy_image_prototype = require( '../../components/c-lazy-image/c-lazy-image.prototype' );
+const c_lazy_image = clonedeep( c_lazy_image_prototype );
+
+c_lazy_image.c_lazy_image_crop_class += ' lrv-u-max-width-150';
+
 module.exports = {
-	"o_sponsored_by_classes": "u-flex u-align-items-center",
-	"o_sponsored_by_title_classes": "lrv-u-color-grey-medium lrv-u-font-family-georgia lrv-u-font-size-10 lrv-u-margin-r-050",
-	"o_sponsored_by_text": "Sponsored by",
-	"o_figure": {
-		"o_figure_classes": "u-width-50",
-		"o_figure_link_url": "#",
-		"o_figure_alt_text": "Thumbnail image",
-		"o_figure_image_url": "https://picsum.photos/57/11"
-	}
+	o_sponsored_by_classes: 'lrv-u-flex lrv-u-align-items-center',
+	o_sponsored_by_title_classes: 'lrv-u-color-grey-medium lrv-u-font-family-georgia lrv-u-font-size-10 lrv-u-margin-r-050',
+	o_sponsored_by_text: 'Sponsored by',
+	c_lazy_image: c_lazy_image
 }

--- a/packages/larva-patterns/objects/o-sponsored-by/o-sponsored-by.twig
+++ b/packages/larva-patterns/objects/o-sponsored-by/o-sponsored-by.twig
@@ -1,7 +1,7 @@
 <div class="o-sponsored-by {{ modifier_class }} {{ o_sponsored_by_classes }}">
 	<span class="{{ o_sponsored_by_title_classes }}">{{ o_sponsored_by_text }}</span>
 
-	{% if o_figure %}
-		{% include "@larva/objects/o-figure/o-figure.twig" with o_figure %}
+	{% if c_lazy_image %}
+		{% include "@larva/components/c-lazy-image/c-lazy-image.twig" with c_lazy_image %}
 	{% endif %}
 </div>

--- a/packages/larva-patterns/objects/o-tease-list/o-tease-list.prototype.js
+++ b/packages/larva-patterns/objects/o-tease-list/o-tease-list.prototype.js
@@ -1,21 +1,14 @@
-const o_figure_prototype = require( '../o-figure/o-figure.prototype' );
-const o_figure = Object.assign( {}, o_figure_prototype );
+const clonedeep = require( 'lodash.clonedeep' );
 
-const c_title_prototype = require( '../../components/c-title/c-title.prototype' );
-const c_title = Object.assign( {}, c_title_prototype );
-
-o_figure.o_figure_crop_class = "lrv-a-crop-16x9";
+const o_tease_prototype = require( '../o-tease/o-tease.prototype' );
+const o_tease = clonedeep( o_tease_prototype );
 
 module.exports = {
-	"o_tease_list_classes": "lrv-a-unstyle-list",
-	"o_tease_list_items": [
-		{
-			"c_title": c_title,
-			"o_figure": o_figure
-		},
-		{
-			"c_title": c_title,
-			"o_figure": o_figure
-		}
+	o_tease_list_classes: 'lrv-a-unstyle-list',
+	o_tease_list_item_classes: '',
+	o_tease_list_items: [
+		o_tease,
+		o_tease,
+		o_tease
 	]
 }

--- a/packages/larva-patterns/objects/o-tease/o-tease.prototype.js
+++ b/packages/larva-patterns/objects/o-tease/o-tease.prototype.js
@@ -1,27 +1,33 @@
 const clonedeep = require( 'lodash.clonedeep' );
 
-const o_figure_prototype = require( '../o-figure/o-figure.prototype' );
-const o_figure = clonedeep( o_figure_prototype );
+const c_lazy_image_prototype = require( '../../components/c-lazy-image/c-lazy-image.prototype' );
+const c_lazy_image = clonedeep( c_lazy_image_prototype );
 
-o_figure.o_figure_crop_class = 'lrv-u-crop-2x3';
-o_figure.o_figure_alt_attr = 'Thumbnail image';
+const c_title_prototype = require( '../../components/c-title/c-title.prototype' );
+const c_title = clonedeep( c_title_prototype );
+
+c_title.c_title_url = false;
+
+const c_tagline_prototype = require( '../../components/c-tagline/c-tagline.prototype' );
+const c_tagline = clonedeep( c_tagline_prototype );
+
+const c_heading_prototype = require( '../../components/c-heading/c-heading.prototype' );
+const c_heading = clonedeep( c_heading_prototype );
+
+c_heading.c_heading_url = false;
+
+c_lazy_image.c_lazy_image_link_url = false;
+c_lazy_image.c_lazy_image_crop_class = 'lrv-a-crop-2x3';
+c_lazy_image.c_lazy_image_alt_attr = 'Post tease thumbnail image';
 
 module.exports = {
-	"o_tease_url": "#",
-	"o_tease_classes": "lrv-u-flex lrv-u-align-items-center",
-	"o_tease_link_classes": "lrv-u-display-contents",
-	"o_tease_primary_classes": "lrv-u-flex-grow-1",
-	"o_tease_secondary_classes": "lrv-u-flex-shrink-0 lrv-u-width-30p",
-	"c_heading": {
-		"c_heading_text": "Breaking News",
-		"c_heading_classes": "lrv-u-font-family-primary lrv-u-font-size-20 lrv-u-font-weight-bold"
-	},
-	"c_title": {
-		"c_title_text": "Title Text"
-	},
-	"c_tagline": {
-		"c_tagline_classes": "",
-		"c_tagline_markup": "Tagline Text"
-	},
-	o_figure: o_figure
+	o_tease_url: '#',
+	o_tease_classes: 'lrv-u-flex lrv-u-align-items-center',
+	o_tease_link_classes: 'lrv-u-display-contents lrv-a-unstyle-link',
+	o_tease_primary_classes: 'lrv-u-flex-grow-1',
+	o_tease_secondary_classes: 'lrv-u-flex-shrink-0 lrv-u-width-30p',
+	c_heading: c_heading,
+	c_title: c_title,
+	c_tagline: c_tagline,
+	c_lazy_image: c_lazy_image
 };

--- a/packages/larva-patterns/objects/o-tease/o-tease.prototype.js
+++ b/packages/larva-patterns/objects/o-tease/o-tease.prototype.js
@@ -23,7 +23,7 @@ c_lazy_image.c_lazy_image_alt_attr = 'Post tease thumbnail image';
 module.exports = {
 	o_tease_url: '#',
 	o_tease_classes: 'lrv-u-flex lrv-u-align-items-center',
-	o_tease_link_classes: 'lrv-u-display-contents lrv-a-unstyle-link',
+	o_tease_link_classes: 'lrv-u-display-contents',
 	o_tease_primary_classes: 'lrv-u-flex-grow-1',
 	o_tease_secondary_classes: 'lrv-u-flex-shrink-0 lrv-u-width-30p',
 	c_heading: c_heading,

--- a/packages/larva-patterns/objects/o-tease/o-tease.twig
+++ b/packages/larva-patterns/objects/o-tease/o-tease.twig
@@ -33,9 +33,9 @@
 			{% endif %}
 		</div>
 
-		{% if o_figure %}
+		{% if c_lazy_image %}
 		<div class="o-tease__secondary {{ o_tease_secondary_classes }}">
-			{% include "@larva/objects/o-figure/o-figure.twig" with o_figure %}
+			{% include "@larva/components/c-lazy-image/c-lazy-image.twig" with c_lazy_image %}
 		</div>
 		{% endif %}
 

--- a/packages/larva/__tests__/lib/utils/getPatternData.test.js
+++ b/packages/larva/__tests__/lib/utils/getPatternData.test.js
@@ -28,10 +28,7 @@ const oneOffStub = {
 };
 
 describe( 'getPatternData', () => {
-	it( 'throws an error if no pattern prototype is found', () => {
-		assert.throws( () => getPatternData( fixture, { type: 'objects', name: 'o-nav' } ), Error );
-	});
-
+	
 	it( 'first returns the pattern object if the schema is found', () => {
 		assert.equal( getPatternData( fixture + '/src/patterns', compStub ), expectedSchema );
 	});

--- a/packages/larva/lib/utils/getPatternData.js
+++ b/packages/larva/lib/utils/getPatternData.js
@@ -17,14 +17,9 @@ function getPatternData( patternsPath, params ) {
 
 	try {
 		let patternData = require( patternPath );
-
-		if ( undefined == typeof patternData ) {
-			patternData = new Error( `Encountered an error getting the pattern data.` );
-		}
-		
 		return patternData;
 	} catch( error ) {
-		console.error( chalk.red.bold( `Encountered an error getting the pattern data.` ) );
+		console.error( chalk.red.bold( `Couldn't get data for ${params.name}.${params.variant}.` ) );
 		console.error( chalk.red( error ) );
 	}
 

--- a/packages/larva/lib/utils/getPatternDataPath.js
+++ b/packages/larva/lib/utils/getPatternDataPath.js
@@ -14,5 +14,6 @@ module.exports = function getPatternDataPath( patternsPath, params ) {
 		return jsonPath;
 	}
 
-	throw new Error( chalk.red( `Couldn\'t find a .prototype.js or .json file for ${params.name}.\nLooked in ${patternsPath}.` ) );
+	console.log( chalk.yellow( `Couldn\'t find data file for ${params.name}.\nLooked in ${patternsPath}.` ) );
+	return undefined;
 }


### PR DESCRIPTION
Break up o-figure into smaller components:
* c-lazy-image
* c-figcaption

General improvements to o-figure:
* Remove c-button, it's not being used anywhere and that should be the responsibility of a module
* Remove option for screen reader text - o-figure should be used with a caption and credit
* Move crop class and inline crop to same tag in c-lazy-image 