### PR TITLE
[o-tease] refact: use c-lazy-image in o-tease

### DIFF
--- a/packages/larva-patterns/objects/o-tease-list/o-tease-list.prototype.js
+++ b/packages/larva-patterns/objects/o-tease-list/o-tease-list.prototype.js
@@ -1,21 +1,14 @@
-const o_figure_prototype = require( '../o-figure/o-figure.prototype' );
-const o_figure = Object.assign( {}, o_figure_prototype );
+const clonedeep = require( 'lodash.clonedeep' );
 
-const c_title_prototype = require( '../../components/c-title/c-title.prototype' );
-const c_title = Object.assign( {}, c_title_prototype );
-
-o_figure.o_figure_crop_class = "lrv-a-crop-16x9";
+const o_tease_prototype = require( '../o-tease/o-tease.prototype' );
+const o_tease = clonedeep( o_tease_prototype );
 
 module.exports = {
-	"o_tease_list_classes": "lrv-a-unstyle-list",
-	"o_tease_list_items": [
-		{
-			"c_title": c_title,
-			"o_figure": o_figure
-		},
-		{
-			"c_title": c_title,
-			"o_figure": o_figure
-		}
+	o_tease_list_classes: 'lrv-a-unstyle-list',
+	o_tease_list_item_classes: '',
+	o_tease_list_items: [
+		o_tease,
+		o_tease,
+		o_tease
 	]
 }

--- a/packages/larva-patterns/objects/o-tease/o-tease.prototype.js
+++ b/packages/larva-patterns/objects/o-tease/o-tease.prototype.js
@@ -1,27 +1,33 @@
 const clonedeep = require( 'lodash.clonedeep' );
 
-const o_figure_prototype = require( '../o-figure/o-figure.prototype' );
-const o_figure = clonedeep( o_figure_prototype );
+const c_lazy_image_prototype = require( '../../components/c-lazy-image/c-lazy-image.prototype' );
+const c_lazy_image = clonedeep( c_lazy_image_prototype );
 
-o_figure.o_figure_crop_class = 'lrv-u-crop-2x3';
-o_figure.o_figure_alt_attr = 'Thumbnail image';
+const c_title_prototype = require( '../../components/c-title/c-title.prototype' );
+const c_title = clonedeep( c_title_prototype );
+
+c_title.c_title_url = false;
+
+const c_tagline_prototype = require( '../../components/c-tagline/c-tagline.prototype' );
+const c_tagline = clonedeep( c_tagline_prototype );
+
+const c_heading_prototype = require( '../../components/c-heading/c-heading.prototype' );
+const c_heading = clonedeep( c_heading_prototype );
+
+c_heading.c_heading_url = false;
+
+c_lazy_image.c_lazy_image_link_url = false;
+c_lazy_image.c_lazy_image_crop_class = 'lrv-a-crop-2x3';
+c_lazy_image.c_lazy_image_alt_attr = 'Post tease thumbnail image';
 
 module.exports = {
-	"o_tease_url": "#",
-	"o_tease_classes": "lrv-u-flex lrv-u-align-items-center",
-	"o_tease_link_classes": "lrv-u-display-contents",
-	"o_tease_primary_classes": "lrv-u-flex-grow-1",
-	"o_tease_secondary_classes": "lrv-u-flex-shrink-0 lrv-u-width-30p",
-	"c_heading": {
-		"c_heading_text": "Breaking News",
-		"c_heading_classes": "lrv-u-font-family-primary lrv-u-font-size-20 lrv-u-font-weight-bold"
-	},
-	"c_title": {
-		"c_title_text": "Title Text"
-	},
-	"c_tagline": {
-		"c_tagline_classes": "",
-		"c_tagline_markup": "Tagline Text"
-	},
-	o_figure: o_figure
+	o_tease_url: '#',
+	o_tease_classes: 'lrv-u-flex lrv-u-align-items-center',
+	o_tease_link_classes: 'lrv-u-display-contents lrv-a-unstyle-link',
+	o_tease_primary_classes: 'lrv-u-flex-grow-1',
+	o_tease_secondary_classes: 'lrv-u-flex-shrink-0 lrv-u-width-30p',
+	c_heading: c_heading,
+	c_title: c_title,
+	c_tagline: c_tagline,
+	c_lazy_image: c_lazy_image
 };

--- a/packages/larva-patterns/objects/o-tease/o-tease.twig
+++ b/packages/larva-patterns/objects/o-tease/o-tease.twig
@@ -33,9 +33,9 @@
 			{% endif %}
 		</div>
 
-		{% if o_figure %}
+		{% if c_lazy_image %}
 		<div class="o-tease__secondary {{ o_tease_secondary_classes }}">
-			{% include "@larva/objects/o-figure/o-figure.twig" with o_figure %}
+			{% include "@larva/components/c-lazy-image/c-lazy-image.twig" with c_lazy_image %}
 		</div>
 		{% endif %}
 


### PR DESCRIPTION
Merge https://github.com/penske-media-corp/pmc-larva/tree/fix/o-figure first.

This PR updates o-tease and o-tease-list schemas to use c-lazy-image.