### PR TITLE
PMCP-1671: Backstop Bugfix

### DIFF
--- a/packages/backstopjs-config/README.md
+++ b/packages/backstopjs-config/README.md
@@ -29,7 +29,7 @@ First install the package and its dependencies. This includes headless Chrome, s
 
 		// This object will provide project-level overrides for the Backstop config.
 		backstop: {
-			// If testing from the Larva mono-repo, replace "project" with "larva", in this path:
+			// If testing default Larva patterns, replace "project" with "larva", in this path:
 			testBaseUrl: 'http://localhost:3000/project',
 			larvaModules: [ 'footer', 'breadcrumbs' ],
 			backstopConfig: {

--- a/packages/backstopjs-config/__tests__/backstopjs-config.test.js
+++ b/packages/backstopjs-config/__tests__/backstopjs-config.test.js
@@ -1,5 +1,4 @@
 const assert = require( 'assert' );
-const path = require( 'path' );
 const getScenarios = require( '../lib/getScenarios' );
 const backstopUtils = require( '../lib/utils' );
 
@@ -28,10 +27,9 @@ const expectations = {
 };
 
 // Basically what happens in index.js
-const scenarios = getScenarios( appConfiguration.testBaseUrl, appConfiguration.testPaths, backstopUtils.prepareTestSelectors( null ), {} );
 
 describe( 'url handling for backstop command', function() {
-
+	
 	it( 'overrides the configuration url with a CLI argument', () => {
 		assert.equal( backstopUtils.maybeUseCliUrl( processMocker.argvWithUrl, appConfiguration.testBaseUrl ), expectations.url );
 	});
@@ -41,11 +39,26 @@ describe( 'url handling for backstop command', function() {
 	});
 
 	it( 'returns a testPaths url if there are no larva modules', () => {
+		const scenarios = getScenarios( 
+			appConfiguration.testBaseUrl, 
+			appConfiguration.testPaths, 
+			backstopUtils.prepareTestSelectors( null ), 
+			{} );
 
 		// Remove larvaModules to test plain URLs
 		delete appConfiguration.larvaModules;
 
 		assert.equal( appConfiguration.testBaseUrl + appConfiguration.testPaths[0], scenarios[0].url );
+	});
+
+	it( 'second scenario has a selector', () => {
+		const scenarios = getScenarios( 
+			appConfiguration.testBaseUrl, 
+			appConfiguration.testPaths, 
+			backstopUtils.prepareTestSelectors( null ), 
+			{} );
+
+		assert.equal( scenarios[1].selectors[0], 'document' );
 	});
 
 });

--- a/packages/backstopjs-config/index.js
+++ b/packages/backstopjs-config/index.js
@@ -33,7 +33,7 @@ if ( undefined === appConfiguration.testBaseUrl && false === urlFromCli ) {
 	process.exit( 1 );
 }
 
-const scenarios = getScenarios( urlBase, paths, selectors,  appConfiguration.testScenario );
+const scenarios = getScenarios( urlBase, paths, selectors, appConfiguration.testScenario );
 
 console.log( chalk.blue( 'Testing paths: \n' + paths ) );
 

--- a/packages/backstopjs-config/lib/getScenarios.js
+++ b/packages/backstopjs-config/lib/getScenarios.js
@@ -1,19 +1,22 @@
 const merge = require( 'webpack-merge' );
 
-module.exports = function getScenarios( urlBase, paths, selectors, scenarioOverride ) {
+module.exports = function getScenarios( urlBase, paths, selectorArr, scenarioOverride ) {
 
 	let scenarios = [];
-	
+
 	for ( let i = 0; i < paths.length; i++ ) {
-		console.log( urlBase + paths[i] );
 		
+		let selectors = 1 === selectorArr.length ? selectorArr[0] : selectorArr[i];
+
+		console.log( urlBase + paths[i] );
+
 		scenarios.push( merge({
 			'label': paths[i],
 			'url': urlBase + paths[i],
 			'hideSelectors': [],
 			'removeSelectors': [],
 			'selectors': [
-				selectors[i]
+				selectors
 			],
 			'delay': 500,
 			'misMatchThreshold': 0.1,


### PR DESCRIPTION
Fix an issue where with QA URL testing the selector override only applied to the first scenario.