### PR TITLE
Enable parent theme logic in parser

### DIFF
--- a/packages/twig-to-php-parser/__tests__/parser-methods.test.js
+++ b/packages/twig-to-php-parser/__tests__/parser-methods.test.js
@@ -9,8 +9,7 @@ const fixture = path.join( __dirname, 'fixtures' );
 
 const expectations = {
 	childInclude: '<?php \\PMC::render_template( CHILD_THEME_PATH . \'/template-parts/patterns/objects/o-nav.php\', $o_nav, true ); ?>',
-	larvaInclude: '<?php \\PMC::render_template( CHILD_THEME_PATH . \'/template-parts/patterns/objects/o-nav.php\', $o_nav, true ); ?>'
-	// larvaInclude: '<?php \\PMC::render_template( PMC_CORE_PATH . \'/template-parts/patterns/objects/o-nav.php\', $o_nav, true ); ?>' - uncomment when core logic is reactivated
+	larvaInclude: '<?php \\PMC::render_template( PMC_CORE_PATH . \'/template-parts/patterns/objects/o-nav.php\', $o_nav, true ); ?>'
 };
 
 describe( 'parse include statements', function() {

--- a/packages/twig-to-php-parser/lib/twig-to-php-parser.php
+++ b/packages/twig-to-php-parser/lib/twig-to-php-parser.php
@@ -255,7 +255,7 @@ function parse_svg_path( $twig_include, $svg_name ) {
 	$svg_path  = '/assets/build/svg/';
 
 	// 08/09/19 - Disabling larva/core theme logic
-	// Not sure if relevant here, but will keep it.
+	// 01/16/20 - Enabled include logic, but this is not needed (yet?)
 	// if ( strpos( $twig_include, "@larva" ) ) {
 	// 	$theme_dir = 'PMC_CORE_PATH';
 	// }

--- a/packages/twig-to-php-parser/lib/twig-to-php-parser.php
+++ b/packages/twig-to-php-parser/lib/twig-to-php-parser.php
@@ -226,10 +226,9 @@ function parse_include_path( $twig_include, $pattern_name, $data_name ) {
 	$theme_dir = 'CHILD_THEME_PATH';
 	$start_name = substr( $pattern_name, 0, 2 );
 
-	// 08/09/19 - Disabling larva/core theme logic
-	// if ( strpos( $twig_include, "@larva" ) ) {
-	// 	$theme_dir = 'PMC_CORE_PATH';
-	// }
+	if ( strpos( $twig_include, '@larva' ) ) {
+		$theme_dir = 'PMC_CORE_PATH';
+	}
 
 	if ( 'c-' === $start_name ) {
 		$directory = 'components';


### PR DESCRIPTION
Dependent on an update to pmc-core-v2 that adds all templates from Larva.