### PR TITLE
Add support for target=“_blank” on the link component

### DIFF
--- a/packages/larva-patterns/components/c-link/c-link.prototype.js
+++ b/packages/larva-patterns/components/c-link/c-link.prototype.js
@@ -3,5 +3,6 @@ module.exports = {
 	c_link_classes: 'lrv-a-unstyle-link',
 	c_link_text: 'A plain text link',
 	c_link_url: '#',
-	c_link_is_external: false,
+	c_link_rel_attr: false,
+	c_link_target_attr: false,
 };

--- a/packages/larva-patterns/components/c-link/c-link.prototype.js
+++ b/packages/larva-patterns/components/c-link/c-link.prototype.js
@@ -2,5 +2,6 @@ module.exports = {
 	modifier_class: '',
 	c_link_classes: 'lrv-a-unstyle-link',
 	c_link_text: 'A plain text link',
-	c_link_url: '#'
+	c_link_url: '#',
+	c_link_is_external: false,
 };

--- a/packages/larva-patterns/components/c-link/c-link.twig
+++ b/packages/larva-patterns/components/c-link/c-link.twig
@@ -1,3 +1,3 @@
-<a class="c-link {{ modifier_class }} {{ c_link_classes }}" href="{{ c_link_url }}">
+<a class="c-link {{ modifier_class }} {{ c_link_classes }}" href="{{ c_link_url }}" {% if c_link_is_external %} target="_blank" rel="noopener" {% endif %}>
 	{{ c_link_text }}
 </a>

--- a/packages/larva-patterns/components/c-link/c-link.twig
+++ b/packages/larva-patterns/components/c-link/c-link.twig
@@ -1,3 +1,3 @@
-<a class="c-link {{ modifier_class }} {{ c_link_classes }}" href="{{ c_link_url }}" {% if c_link_is_external %} target="_blank" rel="noopener" {% endif %}>
+<a class="c-link {{ modifier_class }} {{ c_link_classes }}" href="{{ c_link_url }}" {% if c_link_target_attr %} target="{{ c_link_target_attr }}" {% endif %} {% if c_link_rel_attr %} rel="{{ c_link_rel_attr }}" {% endif %}>
 	{{ c_link_text }}
 </a>


### PR DESCRIPTION
I've extended this component to support toggling a feature on (c_link_is_external) in order to add the target & rel noopener attributes to it. 
The noopener is added as per the following (and to avoid the related security concerns when not having this rel attribute present)
https://jakearchibald.com/2016/performance-benefits-of-rel-noopener/