### PR TITLE
Add missing index to larva-svg

### DIFF
--- a/packages/larva-svg/index.js
+++ b/packages/larva-svg/index.js
@@ -1,9 +1,67 @@
-const gulp = require( 'gulp' );
-const concat = require( 'gulp-concat' );
+'use strict';
 
-exports.sprite = function( done ) {
-	gulp.src( './build/**/*.defs.svg' )
-	.pipe( concat( 'svg-sprite.svg' ) )
-	.pipe( gulp.dest( './build/svg/' ) );
-	done();
+const SVGSpriter = require('svg-sprite');
+const path = require('path');
+const mkdirp = require('mkdirp');
+const globby = require('globby');
+const fs = require('fs');
+const svgoConfig = require( './lib/svgo-config.json' );
+const getSassVarsString = require( './lib/getSassVarsString' );
+
+const config = {
+	dest: 'build',
+	log: null, // Logging verbosity (default: no logging)
+	mode: {
+		defs: {
+			example: true
+		}
+	},
+	shape: {
+		id: {
+			separator: '',
+		},
+		transform: {
+			svgo: svgoConfig
+		}
+	},
+	svg: {
+		dimensionAttributes: false,
+	}
 };
+
+const svgPath = path.join( process.cwd(), './src/' );
+
+const spriter = new SVGSpriter(config);
+const svgFiles = globby.sync( svgPath, {
+	expandDirectories: {
+		extensions: [ 'svg' ],
+	}
+});
+
+let scssIcons = {};
+
+svgFiles.forEach( file => {
+	// Build Sass vars object
+	// TODO: unfinished feature.
+	// scssIcons[ path.basename( file, '.svg' ) ] = fs.readFileSync( file, { encoding: 'utf-8' } );
+
+	spriter.add( file, path.basename( file ), fs.readFileSync( file, { encoding: 'utf-8' } ) );
+});
+
+// Write the Sass variables.
+// TODO: unfinished feature.
+// fs.writeFileSync( path.join( process.cwd(), './build/a-icon-svg.scss' ), getSassVarsString( scssIcons ) );
+
+// Compile the sprite
+spriter.compile( function( error, result, cssData ) {
+	
+	// Run through all configured output modes
+	for ( var mode in result ) {
+
+		// Run through all created resources and write them to disk
+		for ( var type in result[mode] ) {
+			mkdirp.sync( path.dirname( result[mode][type].path ) );
+			fs.writeFileSync( result[mode][type].path, result[mode][type].contents );
+		}
+	}
+});

--- a/packages/larva-svg/index.js
+++ b/packages/larva-svg/index.js
@@ -1,0 +1,9 @@
+const gulp = require( 'gulp' );
+const concat = require( 'gulp-concat' );
+
+exports.sprite = function( done ) {
+	gulp.src( './build/**/*.defs.svg' )
+	.pipe( concat( 'svg-sprite.svg' ) )
+	.pipe( gulp.dest( './build/svg/' ) );
+	done();
+};

--- a/packages/larva-svg/lib/svggo-config.json
+++ b/packages/larva-svg/lib/svggo-config.json
@@ -1,0 +1,67 @@
+{
+	"plugins": [{
+			"removeTitle": false
+		},
+		{
+			"removeDoctype": true
+		},
+		{
+			"removeXMLNS": true
+		},
+		{
+			"removeXMLProcInst": true
+		},
+		{
+			"removeComments": true
+		},
+		{
+			"removeUselessDefs": true
+		},
+		{
+			"removeEmptyAttrs": true
+		},
+		{
+			"removeUselessStrokeAndFill": true
+		},
+		{
+			"removeUnknownsAndDefaults": true
+		},
+		{
+			"convertPathData": false
+		},
+		{
+			"cleanupIDs": true
+		},
+		{
+			"cleanupNumericValues": {
+				"floatPrecision": 3,
+				"leadingZero": true
+			}
+		},
+		{
+			"minifyStyles": true
+		},
+		{
+			"convertTransform": true
+		},
+		{
+			"cleanupAttrs": true
+		},
+		{
+			"convertPathData": true
+		},
+		{
+			"convertShapeToPath": true
+		},
+		{
+			"convertColors": {
+				"shorthex": false
+			}
+		},
+		{
+			"removeAttrs": {
+				"attrs": "fill"
+			}
+		}
+	]
+}


### PR DESCRIPTION
Running `update-latest-larva` results in larva breaking due to the missing code in `larva-svg`. This copies the svg calls in the gulpfile over to an index file in the package.