### PR TITLE
build: stylelint config: allow at-rule @extend

### DIFF
--- a/packages/stylelint-config/index.js
+++ b/packages/stylelint-config/index.js
@@ -33,7 +33,6 @@ module.exports = {
 		'selector-max-combinators': 3,
 		'selector-max-class': 2,
 		'selector-max-compound-selectors': 2,
-		'at-rule-blacklist': [ 'extend' ],
 		'no-unknown-animations': true,
 		'font-family-name-quotes': 'always-where-recommended',
 		'function-name-case': 'lower',


### PR DESCRIPTION
Styling 3rd party DOM structures (e.g. Swiftype)  leaves us with only CSS.
We can use @extend to still make use of larva-css classes.