### PR TITLE
feat: backstopjs: run via docker to avoid cross-platform issues

### DIFF
--- a/packages/backstopjs-config/README.md
+++ b/packages/backstopjs-config/README.md
@@ -13,13 +13,15 @@ This npm package provides configuration for visual regression, or screenshot, te
 
 1. First install the package and its dependencies. This includes headless Chrome, so will take a moment.
 
-	- Install @penskemediacorp/backstopjs-config in the project. Run this command from the same location as package.json.
+	- Install @penskemediacorp/backstopjs-config in the project's assets folder.
 		```language:bash
 		npm install @penskemediacorp/backstopjs-config --save-dev
 		```
 
-	- For now, backstopjs is a peer dependency so you should install this globally:
+	- For now, backstopjs is a peer dependency so you should install this globally. When using `nvm`, globally installed packages are scoped to the nodejs version they were installed on - so be sure to run `nvm install && nvm use` in your project's assets folder before installing.
+
 		```language:bash
+		# install backstopjs globally
 		npm install backstopjs --global
 		```
 

--- a/packages/backstopjs-config/README.md
+++ b/packages/backstopjs-config/README.md
@@ -100,13 +100,17 @@ After you have added the configuration, it is time to run the tests.
 2. You must first generate reference screenshots from a master branch, or other branch that contains the UI you want to test against. When you are on that branch, run the following:
 	```
 	# Generate reference screenshots
-	npm run backstop -- reference
+	npm run backstop:reference
 	```
 3. Checkout to your feature branch, or the branch that contains changes you want to test for regressions.
 4. Run the test with:
 	```
 	# Run the tests, then open an HTML page with a UI for viewing results.
-	npm run backstop -- test
+	npm run backstop:test
+	```
+5. If the the failed tests have been reviewed and are approved changes, run the approve command to save the new reference screenshots:
+	```
+	npm run backstop:approve
 	```
 
 ## Things To Be Aware Of

--- a/packages/backstopjs-config/README.md
+++ b/packages/backstopjs-config/README.md
@@ -18,11 +18,10 @@ This npm package provides configuration for visual regression, or screenshot, te
 		npm install @penskemediacorp/backstopjs-config --save-dev
 		```
 
-	- For now, backstopjs is a peer dependency so you should install this globally. When using `nvm`, globally installed packages are scoped to the nodejs version they were installed on - so be sure to run `nvm install && nvm use` in your project's assets folder before installing.
+	- Pull docker image
 
 		```language:bash
-		# install backstopjs globally
-		npm install backstopjs --global
+		docker pull backstopjs/backstopjs
 		```
 
 2. Add configuration to larva.config.js. You can _either_ test modules from the Larva repo, or test a full page screenshot at specific paths.
@@ -69,8 +68,22 @@ This npm package provides configuration for visual regression, or screenshot, te
 
 	```language:javascript
 	"scripts": {
-		"backstop": "backstop --config=node_modules/@penskemediacorp/backstopjs-config"
+		"backstop": "larva write-json && docker run --rm --network='host' -v $(pwd):/src backstopjs/backstopjs --config=node_modules/@penskemediacorp/backstopjs-config",
+		"backstop:reference": "npm run backstop -- reference",
+		"backstop:test": "npm run backstop -- test && npm run backstop:open-report",
+		"backstop:open-report": "opener ./backstop_data/html_report/index.html",
+		"backstop:pull-docker": "docker pull backstopjs/backstopjs",
 	}
+	```
+
+	Script explanation:
+
+	```bash
+	docker run --rm \
+	-v $(pwd):/src \             # Mount the source code
+	--network='host' \           # Allows docker to access your locally running larva application
+	--user $(id -u):$(id -g) \   # Run as given user (you) - without this, files get saved by root user
+	backstopjs/backstopjs --config=node_modules/@penskemediacorp/backstopjs-config
 	```
 
 ## Running the Tests

--- a/packages/backstopjs-config/README.md
+++ b/packages/backstopjs-config/README.md
@@ -68,9 +68,10 @@ This npm package provides configuration for visual regression, or screenshot, te
 
 	```language:javascript
 	"scripts": {
-		"backstop": "larva write-json && docker run --rm --network='host' -v $(pwd):/src backstopjs/backstopjs --config=node_modules/@penskemediacorp/backstopjs-config",
+		"backstop": "larva write-json && docker run --rm -v $(pwd):/src --network='host' --user $(id -u):$(id -g) backstopjs/backstopjs --config=node_modules/@penskemediacorp/backstopjs-config",
 		"backstop:reference": "npm run backstop -- reference",
 		"backstop:test": "npm run backstop -- test && npm run backstop:open-report",
+		"backstop:approve": "npm run backstop -- approve",
 		"backstop:open-report": "opener ./backstop_data/html_report/index.html",
 		"backstop:pull-docker": "docker pull backstopjs/backstopjs",
 	}

--- a/packages/backstopjs-config/README.md
+++ b/packages/backstopjs-config/README.md
@@ -73,7 +73,7 @@ This npm package provides configuration for visual regression, or screenshot, te
 		"backstop:test": "npm run backstop -- test && npm run backstop:open-report",
 		"backstop:approve": "npm run backstop -- approve",
 		"backstop:open-report": "opener ./backstop_data/html_report/index.html",
-		"backstop:pull-docker": "docker pull backstopjs/backstopjs",
+		"backstop:docker-pull": "docker pull backstopjs/backstopjs",
 	}
 	```
 

--- a/packages/backstopjs-config/README.md
+++ b/packages/backstopjs-config/README.md
@@ -1,6 +1,6 @@
 # Backstop JS Config
 
-This npm package provides configuration for visual regression, or screenshot, testing with [Backstop JS](https://github.com/garris/BackstopJS). 
+This npm package provides configuration for visual regression, or screenshot, testing with [Backstop JS](https://github.com/garris/BackstopJS).
 
 ## Overview of Functionality
 
@@ -11,12 +11,17 @@ This npm package provides configuration for visual regression, or screenshot, te
 
 ## Development Setup
 
-First install the package and its dependencies. This includes headless Chrome, so will take a moment.
+1. First install the package and its dependencies. This includes headless Chrome, so will take a moment.
 
-1. Install the package. Run this command from the same location as package.json.
-	```language:bash
-	npm install @penskemediacorp/backstopjs-config backstopjs --save-dev
-	```
+	- Install @penskemediacorp/backstopjs-config in the project. Run this command from the same location as package.json.
+		```language:bash
+		npm install @penskemediacorp/backstopjs-config --save-dev
+		```
+
+	- For now, backstopjs is a peer dependency so you should install this globally:
+		```language:bash
+		npm install backstopjs --global
+		```
 
 2. Add configuration to larva.config.js. You can _either_ test modules from the Larva repo, or test a full page screenshot at specific paths.
 
@@ -59,7 +64,7 @@ First install the package and its dependencies. This includes headless Chrome, s
 	```
 
 3. Add the npm script to package.json:
-	
+
 	```language:javascript
 	"scripts": {
 		"backstop": "backstop --config=node_modules/@penskemediacorp/backstopjs-config"
@@ -68,15 +73,21 @@ First install the package and its dependencies. This includes headless Chrome, s
 
 ## Running the Tests
 
-After you have added the configuration, it is time to run the tests. 
+After you have added the configuration, it is time to run the tests.
 
-1. You must first generate reference screenshots from a master branch, or other branch that contains the UI you want to test against. When you are on that branch, run the following:
+1. Before testing, Larva must be running:
+
+	```
+	npm run larva
+	```
+
+2. You must first generate reference screenshots from a master branch, or other branch that contains the UI you want to test against. When you are on that branch, run the following:
 	```
 	# Generate reference screenshots
 	npm run backstop -- reference
 	```
-2. Checkout to your feature branch, or the branch that contains changes you want to test for regressions. 
-3. Run the test with: 
+3. Checkout to your feature branch, or the branch that contains changes you want to test for regressions.
+4. Run the test with:
 	```
 	# Run the tests, then open an HTML page with a UI for viewing results.
 	npm run backstop -- test

--- a/packages/backstopjs-config/package.json
+++ b/packages/backstopjs-config/package.json
@@ -27,7 +27,7 @@
     "@penskemediacorp/larva": "^8.5.3-alpha.0",
     "webpack-merge": "^4.2.2"
   },
-  "peerDependencies": {
-    "backstopjs": "^4.3.2"
+  "devDependencies": {
+    "opener": "^1.5.1"
   }
 }


### PR DESCRIPTION
This PR aims to avoid cross-platform issues when running backstopjs locally, as seen here:

![image](https://user-images.githubusercontent.com/4251760/78779599-340dc280-796b-11ea-9d48-a8858174e9e7.png)

See https://github.com/garris/BackstopJS/issues/361 for more info.

BackstopJS provides an official docker image: https://hub.docker.com/r/backstopjs/backstopjs/

### In This PR:

**Docs:**
- Instructions to pull docker image
- Updated npm scripts to be used on new projects

**Dependencies:**
- Removed backstopjs peer dependency - no longer needed if running via docker
- Backstopjs's automatic report opening feature doesn't work via docker, so added cross-platform open utility called `opener` here to achieve this manually in our npm scripts.

### Testing Grounds

Testing taking place on variety-2020 in branch [curtis/docker-backstopjs](https://bitbucket.org/penskemediacorp/pmc-variety-2020/branch/curtis/docker-backstopjs).

_Before you start:_
- Must have docker installed
- Must pull down backstopjs docker image
- Must run `npm install` in variety-202/assets (there's a dependency added temporarily for testing)
`npm run backstopjs:docker-pull`
- Must have larva running before running backstopjs
`npm run larva`


**Linux**

- [X] `npm run backstop:test`: working
- [X] `npm run backstop:reference` working
- [X] delete reference images, run `backstop:reference`: files are owned by?: my user and usergroup (not root)
- [X] report opens after test?

**MacOS**

- [ ] `npm run backstop:test`:
- [ ] `npm run backstop:reference`: 
- [ ] delete reference images, run `backstop:reference`: files are owned by?: 
- [ ] report opens after test?

**Windows**

- [ ] `npm run backstop:test`:
- [ ] `npm run backstop:reference`: 
- [ ] delete reference images, run `backstop:reference`: files are owned by?: 
- [ ] report opens after test?