### PR TITLE
WIP: larva-scss updates

### DIFF
--- a/packages/larva-scss/__tests__/a-crop-generator.test.scss
+++ b/packages/larva-scss/__tests__/a-crop-generator.test.scss
@@ -70,12 +70,35 @@
 				@include _a-crop-generator( $aspect-ratios );
 			}
 
-			@include contains {
+			// Note: ideally this would be `contains` and only contain the
+			// breakpoint block, but having trouble with the
+			// "Compared values have no visual difference." error and
+			// not worth the time to debug it.
+			@include expect {
+				.lrv-a-crop-16x9 {
+					position: relative;
+					padding-bottom: calc( ( 9 / 16 ) * 100%);
+				}
 
-				.lrv-a-crop-16x9\@desktop {
-					@include pmc-breakpoint( desktop ) {
+				.lrv-a-crop-16x9 img {
+					position: absolute;
+					width: 100%;
+					height: 100%;
+					object-fit: cover;
+				}
+
+				@media (min-width: 62.5rem) {
+
+					.lrv-a-crop-16x9\@desktop {
 						position: relative;
 						padding-bottom: calc( ( 9 / 16 ) * 100%);
+					}
+
+					.lrv-a-crop-16x9\@desktop img {
+						position: absolute;
+						width: 100%;
+						height: 100%;
+						object-fit: cover;
 					}
 				}
 			}

--- a/packages/larva-scss/__tests__/a-crop-generator.test.scss
+++ b/packages/larva-scss/__tests__/a-crop-generator.test.scss
@@ -9,7 +9,7 @@
 	);
 
 	@include test('generates non-namespaced crops') {
-		
+
 		@include assert {
 
 			@include output {
@@ -29,8 +29,8 @@
 	}
 
 	@include test('generates namespaced crops') {
-		@import 'fixture/settings';
-		
+		@import 'fixture/setup';
+
 		@include assert {
 
 			@include output {

--- a/packages/larva-scss/__tests__/a-crop-generator.test.scss
+++ b/packages/larva-scss/__tests__/a-crop-generator.test.scss
@@ -1,5 +1,5 @@
-@import "true";
-@import "../lib/tools/tools";
+@import 'true';
+@import '../lib/tools/tools';
 
 @include test-module('@mixin _a-crop-generator') {
 
@@ -70,10 +70,21 @@
 				@include _a-crop-generator( $aspect-ratios );
 			}
 
-			@include contains {
+			@include expect {
 
-				.lrv-a-crop-16x9\@desktop {
-					padding-bottom: calc( ( 9 / 16 ) * 100% );
+				@include pmc-breakpoint( desktop ) {
+
+					.lrv-a-crop-16x9\@desktop {
+						position: relative;
+						padding-bottom: calc( ( 9 / 16 ) * 100%);
+					}
+
+					.lrv-a-crop-16x9\@desktop img {
+						position: absolute;
+						width: 100%;
+						height: 100%;
+						object-fit: cover;
+					}
 				}
 			}
 		}

--- a/packages/larva-scss/__tests__/a-crop-generator.test.scss
+++ b/packages/larva-scss/__tests__/a-crop-generator.test.scss
@@ -3,14 +3,14 @@
 
 @include test-module('@mixin _a-crop-generator') {
 
-	$aspect-ratios: (
-		'16x9': (16, 9),
-		'4x3': (4, 3)
-	);
-
 	@include test('generates non-namespaced crops') {
 
 		@include assert {
+
+			$aspect-ratios: (
+				'16x9': (16, 9),
+				'4x3': (4, 3)
+			);
 
 			@include output {
 				@include _a-crop-generator( $aspect-ratios );
@@ -34,11 +34,45 @@
 		@include assert {
 
 			@include output {
+
+				$aspect-ratios: (
+					'16x9': (16, 9),
+					'4x3': (4, 3)
+				);
+
 				@include _a-crop-generator( $aspect-ratios );
 			}
 
 			@include contains {
 				.lrv-a-crop-16x9 {
+					padding-bottom: calc( ( 9 / 16 ) * 100% );
+				}
+			}
+		}
+	}
+
+	@include test('generates crop breakpoint with condition') {
+
+		$features: (
+			'a-crop-breakpoint': true,
+		);
+
+		@import 'fixture/setup';
+
+		@include assert {
+
+			@include output {
+
+				$aspect-ratios: (
+					'16x9': (16, 9),
+				);
+
+				@include _a-crop-generator( $aspect-ratios );
+			}
+
+			@include contains {
+
+				.lrv-a-crop-16x9\@desktop {
 					padding-bottom: calc( ( 9 / 16 ) * 100% );
 				}
 			}

--- a/packages/larva-scss/__tests__/a-crop-generator.test.scss
+++ b/packages/larva-scss/__tests__/a-crop-generator.test.scss
@@ -1,5 +1,5 @@
-@import 'true';
-@import '../lib/tools/tools';
+@import "true";
+@import "../lib/tools/tools";
 
 @include test-module('@mixin _a-crop-generator') {
 
@@ -70,20 +70,12 @@
 				@include _a-crop-generator( $aspect-ratios );
 			}
 
-			@include expect {
+			@include contains {
 
-				@include pmc-breakpoint( desktop ) {
-
-					.lrv-a-crop-16x9\@desktop {
+				.lrv-a-crop-16x9\@desktop {
+					@include pmc-breakpoint( desktop ) {
 						position: relative;
 						padding-bottom: calc( ( 9 / 16 ) * 100%);
-					}
-
-					.lrv-a-crop-16x9\@desktop img {
-						position: absolute;
-						width: 100%;
-						height: 100%;
-						object-fit: cover;
 					}
 				}
 			}

--- a/packages/larva-scss/__tests__/a-grid-generator.test.scss
+++ b/packages/larva-scss/__tests__/a-grid-generator.test.scss
@@ -69,14 +69,14 @@
 	}
 
 	@include test('generates namepsaced grids') {
-		
-		@import 'fixture/settings';
-		
+
+		@import 'fixture/setup';
+
 		@include assert {
-			
+
 			@include output {
 
-				
+
 				$grids: (
 					(
 						columns: 2,
@@ -132,6 +132,51 @@
 					.lrv-a-cols3\@tablet > .lrv-a-span2\@tablet {
 						flex-basis: 66.66667%;
 					}
+				}
+			}
+
+		}
+	}
+
+	@include test('supports naming update') {
+
+		$features: (
+			'a-grid-namespace': true,
+		);
+
+		@import 'fixture/setup';
+
+		@include assert {
+
+			@include output {
+
+				$grids: (
+					(
+						columns: 3,
+						spans: ( 2, ),
+					),
+				);
+
+				@include _a-grid-generator( $grids );
+			}
+
+			@include expect {
+				.lrv-a-grid-cols-3 {
+					--cols: 3;
+				}
+
+				.lrv-a-grid-cols-3 > * {
+					flex-basis: 33.33333%;
+				}
+
+				@supports (display: grid) {
+					.lrv-a-grid-item-span-2 {
+						grid-column: span 2;
+					}
+				}
+
+				.lrv-a-grid-cols-3 > .lrv-a-grid-item-span-2 {
+					flex-basis: 66.66667%;
 				}
 			}
 

--- a/packages/larva-scss/__tests__/a-grid-generator.test.scss
+++ b/packages/larva-scss/__tests__/a-grid-generator.test.scss
@@ -41,7 +41,7 @@
 					flex-basis: 100%;
 				}
 
-				@media( min-width: 48rem ) {
+				@include pmc-breakpoint( tablet ) {
 					.a-cols3\@tablet {
 						--cols: 3;
 					}
@@ -51,7 +51,7 @@
 					}
 				}
 
-				@media( min-width: 48rem ) {
+				@include pmc-breakpoint( tablet ) {
 
 					.a-span2\@tablet {
 						@supports ( display: grid ) {
@@ -75,7 +75,6 @@
 		@include assert {
 
 			@include output {
-
 
 				$grids: (
 					(
@@ -111,7 +110,7 @@
 					flex-basis: 100%;
 				}
 
-				@media( min-width: 48rem ) {
+				@include pmc-breakpoint( tablet ) {
 					.lrv-a-cols3\@tablet {
 						--cols: 3;
 					}
@@ -121,7 +120,7 @@
 					}
 				}
 
-				@media( min-width: 48rem ) {
+				@include pmc-breakpoint( tablet ) {
 
 					.lrv-a-span2\@tablet {
 						@supports ( display: grid ) {

--- a/packages/larva-scss/__tests__/basic-utility-generator.test.scss
+++ b/packages/larva-scss/__tests__/basic-utility-generator.test.scss
@@ -10,7 +10,7 @@
 		@include assert {
 
 			@include output {
-				
+
 				@include basic-utility-generator(
 					'opacity',
 					(
@@ -30,12 +30,12 @@
 
 	@include test('generates namespaced utility') {
 
-		@import 'fixture/settings';
+		@import 'fixture/setup';
 
 		@include assert {
 
 			@include output {
-				
+
 				@include basic-utility-generator(
 					'opacity',
 					(

--- a/packages/larva-scss/__tests__/fixture/_settings.scss
+++ b/packages/larva-scss/__tests__/fixture/_settings.scss
@@ -1,1 +1,0 @@
-$NAMESPACE: 'lrv-' !global;

--- a/packages/larva-scss/__tests__/fixture/_setup.scss
+++ b/packages/larva-scss/__tests__/fixture/_setup.scss
@@ -4,3 +4,7 @@ $NAMESPACE: 'lrv-' !global;
 	$cols-selector: 'grid-cols-' !global;
 	$span-selector: 'grid-item-span-' !global;
 }
+
+@if variable-exists( 'features' ) and true == map-get( $features, a-crop-breakpoint ) {
+	$a-crop-breakpoint: true !global;
+};

--- a/packages/larva-scss/__tests__/fixture/_setup.scss
+++ b/packages/larva-scss/__tests__/fixture/_setup.scss
@@ -1,0 +1,6 @@
+$NAMESPACE: 'lrv-' !global;
+
+@if variable-exists( 'features' ) and true == map-get( $features, a-grid-namespace ) {
+	$cols-selector: 'grid-cols-' !global;
+	$span-selector: 'grid-item-span-' !global;
+}

--- a/packages/larva-scss/__tests__/spacing-class-generator.test.scss
+++ b/packages/larva-scss/__tests__/spacing-class-generator.test.scss
@@ -46,7 +46,7 @@
 	}
 
 	@include test('generates namespaced classes') {
-		@import 'fixture/settings';
+		@import 'fixture/setup';
 
 		@include assert {
 

--- a/packages/larva-scss/__tests__/text-utility-generators.test.scss
+++ b/packages/larva-scss/__tests__/text-utility-generators.test.scss
@@ -97,7 +97,7 @@
 
 	@include test('generates namespaced classes') {
 
-		@import './fixture/settings';
+		@import './fixture/setup';
 
 		@include assert {
 

--- a/packages/larva-scss/__tests__/token-utility-generator.test.scss
+++ b/packages/larva-scss/__tests__/token-utility-generator.test.scss
@@ -32,12 +32,12 @@
 
 	@include test('generates namespaced text color') {
 
-		@import 'fixture/settings';
+		@import 'fixture/setup';
 
 		@include assert {
 
 			@include output {
-				
+
 				@include token-utility-generator(
 					'color',
 					(

--- a/packages/larva-scss/lib/tools/generators/_a-crop-generator.scss
+++ b/packages/larva-scss/lib/tools/generators/_a-crop-generator.scss
@@ -2,11 +2,16 @@
 
 	$NAMESPACE: '' !default;
 
+	// Can be overwritten in setup.scss
+	$a-crop-breakpoint: false !default;
+
+
 	@if type-of($aspect-ratios) != 'map' {
 		@error "`#{$aspect-ratios}` is not a valid value for $aspect-ratios. It must be map.";
 	}
 
 	@each $name, $sizes in $aspect-ratios {
+
 		.#{$NAMESPACE}a-crop-#{$name} {
 			position: relative;
 			padding-bottom: calc( ( #{nth($sizes, 2)} / #{nth($sizes, 1)} ) * 100% );
@@ -17,6 +22,25 @@
 				height: 100%;
 				object-fit: cover;
 			}
+		}
+
+		@if true == $a-crop-breakpoint {
+
+			@include pmc-breakpoint( desktop ) {
+
+				.#{$NAMESPACE}a-crop-#{$name}\@desktop {
+					position: relative;
+					padding-bottom: calc( ( #{nth($sizes, 2)} / #{nth($sizes, 1)} ) * 100% );
+
+					img {
+						position: absolute;
+						width: 100%;
+						height: 100%;
+						object-fit: cover;
+					}
+				}
+			}
+
 		}
 	}
 }

--- a/packages/larva-scss/lib/tools/generators/_a-crop-generator.scss
+++ b/packages/larva-scss/lib/tools/generators/_a-crop-generator.scss
@@ -26,9 +26,10 @@
 
 		@if true == $a-crop-breakpoint {
 
-			@include pmc-breakpoint( desktop ) {
+			.#{$NAMESPACE}a-crop-#{$name}\@desktop {
 
-				.#{$NAMESPACE}a-crop-#{$name}\@desktop {
+				@include pmc-breakpoint( desktop ) {
+
 					position: relative;
 					padding-bottom: calc( ( #{nth($sizes, 2)} / #{nth($sizes, 1)} ) * 100% );
 

--- a/packages/larva-scss/lib/tools/generators/_a-grid-generator.scss
+++ b/packages/larva-scss/lib/tools/generators/_a-grid-generator.scss
@@ -2,6 +2,9 @@
 
 $NAMESPACE: '' !default;
 
+$cols-selector: 'cols' !default;
+$span-selector: 'span' !default;
+
 @mixin _grid( $columns ) {
 	--cols: #{$columns};
 
@@ -14,12 +17,12 @@ $NAMESPACE: '' !default;
 @mixin _grid-selector( $columns, $breakpoint: false ) {
 	@if $breakpoint {
 		@include pmc-breakpoint( $breakpoint ) {
-			.#{$NAMESPACE}a-cols#{$columns}\@#{$breakpoint} {
+			.#{$NAMESPACE}a-#{$cols-selector}#{$columns}\@#{$breakpoint} {
 				@include _grid( $columns );
 			}
 		}
 	} @else {
-		.#{$NAMESPACE}a-cols#{$columns} {
+		.#{$NAMESPACE}a-#{$cols-selector}#{$columns} {
 			@include _grid( $columns );
 		}
 	}
@@ -40,22 +43,22 @@ $NAMESPACE: '' !default;
 	@if $breakpoint {
 		@include pmc-breakpoint( $breakpoint ) {
 
-			.#{$NAMESPACE}a-span#{$span}\@#{$breakpoint} {
+			.#{$NAMESPACE}a-#{$span-selector}#{$span}\@#{$breakpoint} {
 				@include _grid-column( $columns, $span );
 			}
 
 			// Higher specificity to account for nested grids.
-			.#{$NAMESPACE}a-cols#{$columns}\@#{$breakpoint} > .#{$NAMESPACE}a-span#{$span}\@#{$breakpoint} {
+			.#{$NAMESPACE}a-#{$cols-selector}#{$columns}\@#{$breakpoint} > .#{$NAMESPACE}a-#{$span-selector}#{$span}\@#{$breakpoint} {
 				@include _grid-column-fallback( $columns, $span );
 			}
 
 		}
 	} @else {
-		.#{$NAMESPACE}a-span#{$span} {
+		.#{$NAMESPACE}a-#{$span-selector}#{$span} {
 			@include _grid-column( $columns, $span );
 		}
 
-		.#{$NAMESPACE}a-cols#{$columns} > .#{$NAMESPACE}a-span#{$span} {
+		.#{$NAMESPACE}a-#{$cols-selector}#{$columns} > .#{$NAMESPACE}a-#{$span-selector}#{$span} {
 			@include _grid-column-fallback( $columns, $span );
 		}
 	}

--- a/packages/larva/src/scss/setup.scss
+++ b/packages/larva/src/scss/setup.scss
@@ -5,3 +5,16 @@
 $TOKENS-MAP: $default-map;
 
 $ICONS_BUILD_PATH: '../icons';
+
+// Feature Flags
+$features: (
+	'utilities-v2': true,
+	'breakpoints-v2': true,
+	'a-grid-namespace': true,
+);
+
+// Override grid generator vars according to feature flag.
+@if variable-exists( 'features' ) and true == map-get( $features, a-grid-namespace ) {
+	$cols-selector: 'grid-cols-';
+	$span-selector: 'grid-item-span-';
+}


### PR DESCRIPTION
* Backwards compatible namespace update to a-grid so cols and span selectors are included in generated documentation.