### PR TITLE
GUT-46: Update parser to support template paths from plugin 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+* twig-to-php-parser - Add support for includes to parse to a function from \PMC\Larva\Config to handle paths.
+* twig-to-php-parser - Add support for input `twigDir` and output `phpDir` configuration in larva.config.js
+
+### Fixed
+
+* twig-to-php-parser - Refactor JS wrapper `twigToPhpParser` to accept single configuration object
+
 ## [8.9.0-alpha] - 05-08-2020
 
 ### Added

--- a/packages/twig-to-php-parser/README.md
+++ b/packages/twig-to-php-parser/README.md
@@ -30,10 +30,17 @@ module.exports = {
 	// Other config
 
 	parser: {
-		relativeSrcOverride: false, // The default will look in src/patterns for the source path, but if you want to parse from a different directory, you can add that path here.
-		isCore: false // Or true, if it is the core theme and should parse everything to PMC_CORE_PATH
 	}
 }
+```
+
+The parser object supports the following configuraiton:
+```language-js
+	parser: {
+		twigDir: path.resolve( './new-path/to-twig/' ), // Default /theme/assets/src/patterns.
+		phpDir: path.resolve( './new-path/to-php/' ), // Default /theme/template-parts/patterns.
+		isUsingPlugin: true, // Default false.
+	}
 ```
 
 Then, run the script from the assets directory by executing the package binary like so:

--- a/packages/twig-to-php-parser/__tests__/fixtures/larva.config.js
+++ b/packages/twig-to-php-parser/__tests__/fixtures/larva.config.js
@@ -1,6 +1,0 @@
-module.exports = {
-	parser: {
-		usingPmcPlugin: true,
-		isCore: false,
-	}
-};

--- a/packages/twig-to-php-parser/__tests__/fixtures/larva.config.js
+++ b/packages/twig-to-php-parser/__tests__/fixtures/larva.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+	parser: {
+		usingPmcPlugin: true,
+		isCore: false,
+	}
+};

--- a/packages/twig-to-php-parser/__tests__/parser-methods.test.js
+++ b/packages/twig-to-php-parser/__tests__/parser-methods.test.js
@@ -1,15 +1,17 @@
 const assert = require( 'assert' );
 const path = require( 'path' );
-const fs = require( 'fs' );
 
 const parserMethods = require( '../index.js' ).methods;
-const exec = require( 'child_process' ).exec;
 
 const fixture = path.join( __dirname, 'fixtures' );
+const config = require( fixture + '/larva.config.js' ).parser;
+
+console.log( config );
 
 const expectations = {
 	childInclude: '<?php \\PMC::render_template( CHILD_THEME_PATH . \'/template-parts/patterns/objects/o-nav.php\', $o_nav, true ); ?>',
-	larvaInclude: '<?php \\PMC::render_template( PMC_CORE_PATH . \'/template-parts/patterns/objects/o-nav.php\', $o_nav, true ); ?>'
+	larvaInclude: '<?php \\PMC::render_template( PMC_CORE_PATH . \'/template-parts/patterns/objects/o-nav.php\', $o_nav, true ); ?>',
+	pluginEnabled: '<?php \\PMC::render_template( \\PMC\\Larva\\Config::get_instance()->get_brand_directory() . \'/template-parts/patterns/objects/o-nav.php\', $o_nav, true ); ?>',
 };
 
 describe( 'parse include statements', function() {
@@ -27,16 +29,31 @@ describe( 'parse include statements', function() {
 	});
 
 	it( 'if larva namespace, parsed path references the parent theme', ( done ) => {
+
 		parserMethods.parseIncludePath(
 			'{% include "@larva/objects/o-nav.twig" with o_nav %}',
 			'o-nav',
-			'o_nav' )
+			'o_nav',
+			config
+		)
 		.catch( e => console.log( e ) )
 		.then( ( result ) => {
 			assert.equal( result, expectations.larvaInclude );
 			done();
 		});
-	});
+	} );
+
+	it( 'if plugin is enabled, parsed to the function call', ( done ) => {
+		parserMethods.parseIncludePath(
+			'{% include "@larva/objects/o-nav.twig" with o_nav %}',
+			'o-nav',
+			'o_nav' )
+			.catch( e => console.log( e ) )
+			.then( ( result ) => {
+				assert.equal( result, expectations.pluginEnabled );
+				done();
+			} );
+	} );
 
 });
 

--- a/packages/twig-to-php-parser/__tests__/parser-methods.test.js
+++ b/packages/twig-to-php-parser/__tests__/parser-methods.test.js
@@ -43,7 +43,7 @@ describe( 'parse include statements', function() {
 		});
 	} );
 
-	it( 'if plugin is enabled, parsed to the function call', ( done ) => {
+	it( 'if plugin is enabled, output to the function call', ( done ) => {
 		parserMethods.parseIncludePath(
 			'{% include "@larva/objects/o-nav.twig" with o_nav %}',
 			'o-nav',

--- a/packages/twig-to-php-parser/__tests__/parser-methods.test.js
+++ b/packages/twig-to-php-parser/__tests__/parser-methods.test.js
@@ -6,7 +6,7 @@ const parserMethods = require( '../index.js' ).methods;
 const expectations = {
 	childInclude: '<?php \\PMC::render_template( CHILD_THEME_PATH . \'/template-parts/patterns/objects/o-nav.php\', $o_nav, true ); ?>',
 	larvaInclude: '<?php \\PMC::render_template( PMC_CORE_PATH . \'/template-parts/patterns/objects/o-nav.php\', $o_nav, true ); ?>',
-	pluginEnabled: '<?php \\PMC::render_template( \\PMC\\Larva\\Config::get_instance()->get_brand_directory() . \'/template-parts/patterns/objects/o-nav.php\', $o_nav, true ); ?>',
+	pluginEnabled: '<?php \\PMC::render_template( \\PMC\\Larva\\Config::get_instance()->get( \'brand_directory\' ) . \'/template-parts/patterns/objects/o-nav.php\', $o_nav, true ); ?>',
 };
 
 describe( 'parse include statements', function() {

--- a/packages/twig-to-php-parser/__tests__/parser-methods.test.js
+++ b/packages/twig-to-php-parser/__tests__/parser-methods.test.js
@@ -3,11 +3,6 @@ const path = require( 'path' );
 
 const parserMethods = require( '../index.js' ).methods;
 
-const fixture = path.join( __dirname, 'fixtures' );
-const config = require( fixture + '/larva.config.js' ).parser;
-
-console.log( config );
-
 const expectations = {
 	childInclude: '<?php \\PMC::render_template( CHILD_THEME_PATH . \'/template-parts/patterns/objects/o-nav.php\', $o_nav, true ); ?>',
 	larvaInclude: '<?php \\PMC::render_template( PMC_CORE_PATH . \'/template-parts/patterns/objects/o-nav.php\', $o_nav, true ); ?>',
@@ -33,8 +28,7 @@ describe( 'parse include statements', function() {
 		parserMethods.parseIncludePath(
 			'{% include "@larva/objects/o-nav.twig" with o_nav %}',
 			'o-nav',
-			'o_nav',
-			config
+			'o_nav'
 		)
 		.catch( e => console.log( e ) )
 		.then( ( result ) => {
@@ -44,10 +38,12 @@ describe( 'parse include statements', function() {
 	} );
 
 	it( 'if plugin is enabled, output to the function call', ( done ) => {
+
 		parserMethods.parseIncludePath(
 			'{% include "@larva/objects/o-nav.twig" with o_nav %}',
 			'o-nav',
-			'o_nav' )
+			'o_nav',
+			true )
 			.catch( e => console.log( e ) )
 			.then( ( result ) => {
 				assert.equal( result, expectations.pluginEnabled );

--- a/packages/twig-to-php-parser/__tests__/twig-to-php-parser.test.js
+++ b/packages/twig-to-php-parser/__tests__/twig-to-php-parser.test.js
@@ -5,11 +5,11 @@ const twigToPhpParser = require( '../index' ).twigToPhpParser;
 const exec = require( 'child_process' ).exec;
 
 const fixture = path.join( __dirname, 'fixtures' );
+const expectedDir = `${fixture}/template-parts-expected/patterns/`;
 
-const pathConfig = {
+const config = {
 	twigDir: `${fixture}/src/patterns/`,
 	phpDir: `${fixture}/template-parts/patterns/`,
-	expectedDir: `${fixture}/template-parts-expected/patterns/`,
 };
 
 const patternShortPaths = [
@@ -25,36 +25,37 @@ const patternShortPaths = [
 describe( 'twig to php parser', function() {
 
 	beforeEach( ( done ) => {
-		exec( 'mkdir ' + pathConfig.phpDir, ( err  ) => {
+
+		exec( 'mkdir ' + config.phpDir, ( err  ) => {
 			if ( err ) {
 				console.error( err );
 			}
 		});
 
-		return twigToPhpParser( pathConfig.twigDir, pathConfig.phpDir )
+		return twigToPhpParser( config )
 		.catch( ( e ) => console.log( e ) )
 		.then( ( result ) => done() ); // Catch PHP errors.
 	});
 
 	it( 'creates new files and directories for objects, components, and modules', ( done ) => {
-		assert.equal( fs.existsSync( pathConfig.phpDir + 'objects/o-nav.php' ), true );
-		assert.equal( fs.existsSync( pathConfig.phpDir + 'components/c-nav-link.php' ), true );
-		assert.equal( fs.existsSync( pathConfig.phpDir + 'modules/breadcrumbs.php' ), true );
+		assert.equal( fs.existsSync( config.phpDir + 'objects/o-nav.php' ), true );
+		assert.equal( fs.existsSync( config.phpDir + 'components/c-nav-link.php' ), true );
+		assert.equal( fs.existsSync( config.phpDir + 'modules/breadcrumbs.php' ), true );
 		done();
 	});
 
 	it( 'parses patterns as expected', ( done ) => {
 		patternShortPaths.forEach( ( shortpath ) => {
-			let expectedContents = fs.readFileSync( pathConfig.expectedDir + shortpath ).toString();
-			let actualContents = fs.readFileSync( pathConfig.phpDir + shortpath ).toString();
-			
+			let expectedContents = fs.readFileSync( expectedDir + shortpath ).toString();
+			let actualContents = fs.readFileSync( config.phpDir + shortpath ).toString();
+
 			assert.equal( expectedContents, actualContents );
 		});
 		done();
 	});
 
 	afterEach( () => {
-		exec( 'rm -r ' + pathConfig.phpDir, ( err ) => {
+		exec( 'rm -r ' + config.phpDir, ( err ) => {
 			if ( err ) {
 				console.error( err );
 			}

--- a/packages/twig-to-php-parser/index.js
+++ b/packages/twig-to-php-parser/index.js
@@ -2,17 +2,34 @@ const execPhp = require( 'exec-php' );
 const path = require( 'path' );
 const chalk = require( 'chalk' );
 const getAppConfiguration = require( '@penskemediacorp/larva' ).getConfig;
-
+const config = getAppConfiguration( 'parser' );
 
 /**
  * Twig to PHP Parser
  *
- * @param {string} twigDir Absolute path to Twig patterns
- * @param {string} phpDir Absolute path to PHP output
- * @param {object} config Optional object containing configuration
+ * @param {object} config Optional object containing configuration. See the
+ *                        package README for supported configuration.
+ * }
  */
 
-function twigToPhpParser( twigDir, phpDir, config = {} ) {
+function twigToPhpParser( config = {} ) {
+
+	// TODO: we need some kind of wrapper here for config.
+	let twigDir = path.join( process.cwd(), './src/patterns' );
+	let phpDir = path.join( process.cwd(), '../template-parts/patterns' );
+	let isUsingPlugin = false;
+
+	if ( 'undefined' !== typeof config.twigDir ) {
+		twigDir = config.twigDir;
+	}
+
+	if ( 'undefined' !== typeof config.isUsingPlugin ) {
+		isUsingPlugin = config.isUsingPlugin;
+	}
+
+	if ( 'undefined' !== typeof config.phpDir ) {
+		phpDir = config.phpDir;
+	}
 
 	return new Promise( ( resolve, reject ) => {
 
@@ -22,7 +39,7 @@ function twigToPhpParser( twigDir, phpDir, config = {} ) {
 				reject( error );
 			}
 
-			php.twig_to_php_parser( twigDir, phpDir, function( error, result, output, printed ) {
+			php.twig_to_php_parser( twigDir, phpDir, isUsingPlugin, function( error, result, output, printed ) {
 
 				if ( error ) {
 					reject( error );
@@ -70,24 +87,10 @@ module.exports = {
 		parseIncludePath: parseIncludePath
 	},
 	run: () => {
-
-		const config = getAppConfiguration( 'parser' );
-
-		let twigDir = path.join( process.cwd(), './src/patterns' );
-		let phpDir = path.join( process.cwd(), '../template-parts/patterns' );
-
-		if ( 'undefined' !== typeof config.twigDir ) {
-			twigDir = config.twigDir;
-		}
-
-		if ( 'undefined' !== typeof config.phpDir ) {
-			phpDir = config.phpDir;
-		}
-
-		twigToPhpParser( twigDir, phpDir, config )
+		twigToPhpParser( config )
 			.catch( e => console.log( e ) ) // PHP errors
 			.then( result => console.log(
-				chalk.green( `Completed parsing Twig templates to PHP. \nFrom: ${twigDir} \nTo: ${phpDir}.` )
+				chalk.green( 'Completed parsing Twig templates to PHP.' )
 			) )
 			.catch( e => console.log( e ) );
 	}

--- a/packages/twig-to-php-parser/index.js
+++ b/packages/twig-to-php-parser/index.js
@@ -2,14 +2,33 @@ const execPhp = require( 'exec-php' );
 const path = require( 'path' );
 const chalk = require( 'chalk' );
 const getAppConfiguration = require( '@penskemediacorp/larva' ).getConfig;
-const RELATIVE_OUPUT_PATH = '../template-parts/patterns'; // Not permitted to override this because it will break the include paths.
+
+const config = getAppConfiguration( 'parser' );
+
+const twigDir = ( () => {
+	if ( undefined !== config.twigDir ) {
+		return config.twigDir;
+	}
+
+	// Default
+	return path.resolve( process.cwd(), './src/patterns' );
+} )();
+
+const phpDir = ( () => {
+	if ( undefined !== config.phpDir ) {
+		return config.phpDir;
+	}
+
+	// Default
+	return path.resolve( process.cwd(), '../template-parts/patterns' );
+} )();
 
 /**
  * Twig to PHP Parser
- * 
+ *
  * @param {string} twigDirPath Absolute path to Twig patterns
  * @param {string} phpDirPath Absolute path to PHP output
- * @param {object} config Containing 
+ * @param {object} config Optional object containing configuration
  */
 
 function twigToPhpParser( twigDirPath, phpDirPath, config = {} ) {
@@ -70,10 +89,7 @@ module.exports = {
 		parseIncludePath: parseIncludePath
 	},
 	run: () => {
-		let config = getAppConfiguration( 'parser' );
-		let relativeSrcPath = config.relativeSrcOverride || './src/patterns';
-
-		twigToPhpParser( path.resolve( process.cwd(), relativeSrcPath ), path.resolve( process.cwd(), RELATIVE_OUPUT_PATH ), config )
+		twigToPhpParser( twigDir, phpDir, config )
 		.catch( e => console.log( e ) ) // PHP errors
 		.then( result => console.log( chalk.green( 'Completed parsing Twig templates to PHP.' ) ) )
 		.catch( e => console.log( e ) );

--- a/packages/twig-to-php-parser/index.js
+++ b/packages/twig-to-php-parser/index.js
@@ -3,35 +3,16 @@ const path = require( 'path' );
 const chalk = require( 'chalk' );
 const getAppConfiguration = require( '@penskemediacorp/larva' ).getConfig;
 
-const config = getAppConfiguration( 'parser' );
-
-const twigDir = ( () => {
-	if ( undefined !== typeof config.twigDir ) {
-		return config.twigDir;
-	}
-
-	// Default
-	return path.resolve( process.cwd(), './src/patterns' );
-} )();
-
-const phpDir = ( () => {
-	if ( undefined !== typeof config.phpDir ) {
-		return config.phpDir;
-	}
-
-	// Default
-	return path.resolve( process.cwd(), '../template-parts/patterns' );
-} )();
 
 /**
  * Twig to PHP Parser
  *
- * @param {string} twigDirPath Absolute path to Twig patterns
- * @param {string} phpDirPath Absolute path to PHP output
+ * @param {string} twigDir Absolute path to Twig patterns
+ * @param {string} phpDir Absolute path to PHP output
  * @param {object} config Optional object containing configuration
  */
 
-function twigToPhpParser( twigDirPath, phpDirPath, config = {} ) {
+function twigToPhpParser( twigDir, phpDir, config = {} ) {
 
 	return new Promise( ( resolve, reject ) => {
 
@@ -41,7 +22,7 @@ function twigToPhpParser( twigDirPath, phpDirPath, config = {} ) {
 				reject( error );
 			}
 
-			php.twig_to_php_parser( twigDirPath, phpDirPath, function( error, result, output, printed ) {
+			php.twig_to_php_parser( twigDir, phpDir, function( error, result, output, printed ) {
 
 				if ( error ) {
 					reject( error );
@@ -89,9 +70,25 @@ module.exports = {
 		parseIncludePath: parseIncludePath
 	},
 	run: () => {
+
+		const config = getAppConfiguration( 'parser' );
+
+		let twigDir = path.join( process.cwd(), './src/patterns' );
+		let phpDir = path.join( process.cwd(), '../template-parts/patterns' );
+
+		if ( 'undefined' !== typeof config.twigDir ) {
+			twigDir = config.twigDir;
+		}
+
+		if ( 'undefined' !== typeof config.phpDir ) {
+			phpDir = config.phpDir;
+		}
+
 		twigToPhpParser( twigDir, phpDir, config )
-		.catch( e => console.log( e ) ) // PHP errors
-		.then( result => console.log( chalk.green( 'Completed parsing Twig templates to PHP.' ) ) )
-		.catch( e => console.log( e ) );
+			.catch( e => console.log( e ) ) // PHP errors
+			.then( result => console.log(
+				chalk.green( `Completed parsing Twig templates to PHP. \nFrom: ${twigDir} \nTo: ${phpDir}.` )
+			) )
+			.catch( e => console.log( e ) );
 	}
 };

--- a/packages/twig-to-php-parser/index.js
+++ b/packages/twig-to-php-parser/index.js
@@ -6,7 +6,7 @@ const getAppConfiguration = require( '@penskemediacorp/larva' ).getConfig;
 const config = getAppConfiguration( 'parser' );
 
 const twigDir = ( () => {
-	if ( undefined !== config.twigDir ) {
+	if ( undefined !== typeof config.twigDir ) {
 		return config.twigDir;
 	}
 
@@ -15,7 +15,7 @@ const twigDir = ( () => {
 } )();
 
 const phpDir = ( () => {
-	if ( undefined !== config.phpDir ) {
+	if ( undefined !== typeof config.phpDir ) {
 		return config.phpDir;
 	}
 
@@ -57,7 +57,7 @@ function twigToPhpParser( twigDirPath, phpDirPath, config = {} ) {
 
 };
 
-function parseIncludePath( twigIncludeStr, patternName, dataName, config = {} ) {
+function parseIncludePath( twigIncludeStr, patternName, dataName, isUsingPlugin = false ) {
 
 	return new Promise( ( resolve, reject ) => {
 
@@ -67,7 +67,7 @@ function parseIncludePath( twigIncludeStr, patternName, dataName, config = {} ) 
 				reject( error );
 			}
 
-			php.parse_include_path( twigIncludeStr, patternName, dataName, function( error, result, output, printed ) {
+			php.parse_include_path( twigIncludeStr, patternName, dataName, isUsingPlugin, function( error, result, output, printed ) {
 
 				if ( error ) {
 					reject( error );

--- a/packages/twig-to-php-parser/index.js
+++ b/packages/twig-to-php-parser/index.js
@@ -15,8 +15,8 @@ const config = getAppConfiguration( 'parser' );
 function twigToPhpParser( config = {} ) {
 
 	// TODO: We need some kind of wrapper here for config...or better:
-	// move this to pmc-plugins/pmc-larva and scrap this strings JS
-	// wrapper situation, and use Larva\Config for these paths.
+	// move this to pmc-plugins/pmc-larva and scrap this awkward JS
+	// execPhp wrapper situation, and use Larva\Config for this config.
 	let twigDir = path.join( process.cwd(), './src/patterns' );
 	let phpDir = path.join( process.cwd(), '../template-parts/patterns' );
 	let isUsingPlugin = false;

--- a/packages/twig-to-php-parser/index.js
+++ b/packages/twig-to-php-parser/index.js
@@ -14,7 +14,9 @@ const config = getAppConfiguration( 'parser' );
 
 function twigToPhpParser( config = {} ) {
 
-	// TODO: we need some kind of wrapper here for config.
+	// TODO: We need some kind of wrapper here for config...or better:
+	// move this to pmc-plugins/pmc-larva and scrap this strings JS
+	// wrapper situation, and use Larva\Config for these paths.
 	let twigDir = path.join( process.cwd(), './src/patterns' );
 	let phpDir = path.join( process.cwd(), '../template-parts/patterns' );
 	let isUsingPlugin = false;

--- a/packages/twig-to-php-parser/lib/twig-to-php-parser.php
+++ b/packages/twig-to-php-parser/lib/twig-to-php-parser.php
@@ -227,24 +227,26 @@ function parse_include_path( $twig_include, $pattern_name, $data_name, $is_using
 	$brand_directory = 'CHILD_THEME_PATH';
 	$start_name = substr( $pattern_name, 0, 2 );
 
-	if ( strpos( $twig_include, '@larva' ) ) {
-		$brand_directory = 'PMC_CORE_PATH';
+	if ( true === $is_using_plugin ) {
+		$brand_directory = "\PMC\Larva\Config::get_instance()->get( 'brand_directory' )";
+	} else {
+
+		// This logic is only supported if not using the plugin
+		if ( strpos( $twig_include, '@larva' ) ) {
+			$brand_directory = 'PMC_CORE_PATH';
+		}
 	}
+
 
 	if ( 'c-' === $start_name ) {
-		$directory = 'components';
+		$pattern_directory = 'components';
 	} elseif ( 'o-' === $start_name ) {
-		$directory = 'objects';
+		$pattern_directory = 'objects';
 	} elseif ( '-' !== substr( $pattern_name, 1, 2 ) ) { // If there is no namespace, it is a module.
-		$directory = 'modules';
+		$pattern_directory = 'modules';
 	}
 
-
-	if ( true === $is_using_plugin ) {
-		$brand_directory = '\PMC\Larva\Config::get_instance()->get_brand_directory()';
-	}
-
-	return "<?php \PMC::render_template( " . $theme_dir . " . '/template-parts/patterns/" . $directory . "/" . $pattern_name . ".php', $" . $data_name . ', true ); ?>';
+	return "<?php \PMC::render_template( " . $brand_directory . " . '/template-parts/patterns/" . $pattern_directory . "/" . $pattern_name . ".php', $" . $data_name . ', true ); ?>';
 
 }
 

--- a/packages/twig-to-php-parser/lib/twig-to-php-parser.php
+++ b/packages/twig-to-php-parser/lib/twig-to-php-parser.php
@@ -222,12 +222,13 @@ function twig_to_php_parser( $patterns_dir_path, $template_dir_path ) {
  *
  * @return string PMC::render_template call
  */
-function parse_include_path( $twig_include, $pattern_name, $data_name ) {
-	$theme_dir = 'CHILD_THEME_PATH';
+function parse_include_path( $twig_include, $pattern_name, $data_name, $is_using_plugin ) {
+
+	$brand_directory = 'CHILD_THEME_PATH';
 	$start_name = substr( $pattern_name, 0, 2 );
 
 	if ( strpos( $twig_include, '@larva' ) ) {
-		$theme_dir = 'PMC_CORE_PATH';
+		$brand_directory = 'PMC_CORE_PATH';
 	}
 
 	if ( 'c-' === $start_name ) {
@@ -238,7 +239,13 @@ function parse_include_path( $twig_include, $pattern_name, $data_name ) {
 		$directory = 'modules';
 	}
 
-	 return "<?php \PMC::render_template( " . $theme_dir . " . '/template-parts/patterns/" . $directory . "/" . $pattern_name . ".php', $" . $data_name . ', true ); ?>';
+
+	if ( true === $is_using_plugin ) {
+		$brand_directory = '\PMC\Larva\Config::get_instance()->get_brand_directory()';
+	}
+
+	return "<?php \PMC::render_template( " . $theme_dir . " . '/template-parts/patterns/" . $directory . "/" . $pattern_name . ".php', $" . $data_name . ', true ); ?>';
+
 }
 
 

--- a/packages/twig-to-php-parser/lib/twig-to-php-parser.php
+++ b/packages/twig-to-php-parser/lib/twig-to-php-parser.php
@@ -10,7 +10,7 @@
  * @author Lara Schenck and Amit Sannad
  */
 
-function twig_to_php_parser( $patterns_dir_path, $template_dir_path ) {
+function twig_to_php_parser( $patterns_dir_path, $template_dir_path, $is_using_plugin ) {
 	$twig_files        = [];
 
 	$twig_dir_iterator      = new \RecursiveDirectoryIterator( $patterns_dir_path );
@@ -164,7 +164,8 @@ function twig_to_php_parser( $patterns_dir_path, $template_dir_path ) {
 			$include_replacements[ $count ] = parse_include_path(
 				$include,
 				$include_matches[3][ $count ],
-				$include_matches[6][ $count ]
+				$include_matches[6][ $count ],
+				$is_using_plugin
 			);
 			$count ++;
 		}


### PR DESCRIPTION
This `twig-to-php-parser` package is pretty smelly. In a future Larva chat, we can discuss moving this to the pmc-larva plugin and handle the configuration there, or another approach to clean up how config is handled in this mono-repo. Or not.

Changes included here in this PR are noted in the changelog. 