### PR TITLE
[GUT-45] fix: update include path for plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [8.10.0-alpha] - 05-11-2020
 
+### Fixed
+
+* twig-to-php-parser - Update the path for plugin patterns to point to build/patterns.
+
 ### Added
 
 * twig-to-php-parser - Add support for includes to parse to a function from \PMC\Larva\Config to handle paths.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [8.10.0-alpha] - 05-11-2020
-
 ### Fixed
 
 * twig-to-php-parser - Update the path for plugin patterns to point to build/patterns.
+
+## [8.10.0-alpha] - 05-11-2020
 
 ### Added
 

--- a/packages/twig-to-php-parser/__tests__/parser-methods.test.js
+++ b/packages/twig-to-php-parser/__tests__/parser-methods.test.js
@@ -6,7 +6,7 @@ const parserMethods = require( '../index.js' ).methods;
 const expectations = {
 	childInclude: '<?php \\PMC::render_template( CHILD_THEME_PATH . \'/template-parts/patterns/objects/o-nav.php\', $o_nav, true ); ?>',
 	larvaInclude: '<?php \\PMC::render_template( PMC_CORE_PATH . \'/template-parts/patterns/objects/o-nav.php\', $o_nav, true ); ?>',
-	pluginEnabled: '<?php \\PMC::render_template( \\PMC\\Larva\\Config::get_instance()->get( \'brand_directory\' ) . \'/template-parts/patterns/objects/o-nav.php\', $o_nav, true ); ?>',
+	pluginEnabled: '<?php \\PMC::render_template( \\PMC\\Larva\\Config::get_instance()->get( \'brand_directory\' ) . \'/build/patterns/objects/o-nav.php\', $o_nav, true ); ?>',
 };
 
 describe( 'parse include statements', function() {

--- a/packages/twig-to-php-parser/lib/twig-to-php-parser.php
+++ b/packages/twig-to-php-parser/lib/twig-to-php-parser.php
@@ -226,28 +226,28 @@ function twig_to_php_parser( $patterns_dir_path, $template_dir_path, $is_using_p
 function parse_include_path( $twig_include, $pattern_name, $data_name, $is_using_plugin ) {
 
 	$brand_directory = 'CHILD_THEME_PATH';
+	$pattern_directory = '/template-parts/patterns/';
 	$start_name = substr( $pattern_name, 0, 2 );
 
 	if ( true === $is_using_plugin ) {
+		$pattern_directory = '/build/patterns/';
 		$brand_directory = "\PMC\Larva\Config::get_instance()->get( 'brand_directory' )";
 	} else {
-
 		// This logic is only supported if not using the plugin
 		if ( strpos( $twig_include, '@larva' ) ) {
 			$brand_directory = 'PMC_CORE_PATH';
 		}
 	}
 
-
 	if ( 'c-' === $start_name ) {
-		$pattern_directory = 'components';
+		$pattern_directory .= 'components';
 	} elseif ( 'o-' === $start_name ) {
-		$pattern_directory = 'objects';
+		$pattern_directory .= 'objects';
 	} elseif ( '-' !== substr( $pattern_name, 1, 2 ) ) { // If there is no namespace, it is a module.
-		$pattern_directory = 'modules';
+		$pattern_directory .= 'modules';
 	}
 
-	return "<?php \PMC::render_template( " . $brand_directory . " . '/template-parts/patterns/" . $pattern_directory . "/" . $pattern_name . ".php', $" . $data_name . ', true ); ?>';
+	return "<?php \PMC::render_template( " . $brand_directory . " . '" . $pattern_directory . "/" . $pattern_name . ".php', $" . $data_name . ', true ); ?>';
 
 }
 


### PR DESCRIPTION
Since we will not have other template parts in the pmc-plugins/pmc-larva repo, the built patterns can be stored in the build/ directory.

This will also discourage the addition of any controller code to the plugin. That should live in the theme or another plugin.