### PR TITLE
Update parser to new plugin method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [8.14.19-alpha] - 07-23-2020
+
+* twig-to-php-parser - Update isUsingPlugin `include` path transformation to use new render_pattern_template method
+
+## [8.14.18-alpha] - 07-21-2020
+
+* larva - Fix missing @penskemediacorp/eslint-config dependency
+
 ## [8.14.17-alpha] - 07-17-2020
 
 * eslint-config - update reference to wp eslint package

--- a/packages/twig-to-php-parser/__tests__/parser-methods.test.js
+++ b/packages/twig-to-php-parser/__tests__/parser-methods.test.js
@@ -5,8 +5,7 @@ const parserMethods = require( '../index.js' ).methods;
 const expectations = {
 	childInclude: '<?php \\PMC::render_template( CHILD_THEME_PATH . \'/template-parts/patterns/objects/o-nav.php\', $o_nav, true ); ?>',
 	larvaInclude: '<?php \\PMC::render_template( PMC_CORE_PATH . \'/template-parts/patterns/objects/o-nav.php\', $o_nav, true ); ?>',
-	larvaIncludePluginEnabled: '<?php \\PMC::render_template( \\PMC\\Larva\\Config::get_instance()->get( \'core_directory\' ) . \'/build/patterns/objects/o-nav.php\', $o_nav, true ); ?>',
-	pluginEnabled: '<?php \\PMC::render_template( \\PMC\\Larva\\Config::get_instance()->get( \'brand_directory\' ) . \'/build/patterns/objects/o-nav.php\', $o_nav, true ); ?>'
+	pluginEnabled: '<?php \\PMC\\Larva\\Pattern::get_instance()->render_pattern_template( \'objects/o-nav\', $o_nav, true ); ?>'
 };
 
 describe( 'parse include statements', function() {
@@ -37,22 +36,7 @@ describe( 'parse include statements', function() {
 		} );
 	} );
 
-	it( 'if plugin is enabled, call config with core_directory', ( done ) => {
-
-		parserMethods.parseIncludePath(
-			'{% include "@larva/objects/o-nav.twig" with o_nav %}',
-			'o-nav',
-			'o_nav',
-			true
-		)
-		.catch( e => console.log( e ) )
-		.then( ( result ) => {
-			assert.equal( result, expectations.larvaIncludePluginEnabled );
-			done();
-		});
-	} );
-
-	it( 'if plugin is enabled, call config with brand_directory', ( done ) => {
+	it( 'if plugin is enabled, use the render_pattern_template method from Larva', ( done ) => {
 
 		parserMethods.parseIncludePath(
 			'{% include "@project/objects/o-nav.twig" with o_nav %}',

--- a/packages/twig-to-php-parser/lib/twig-to-php-parser.php
+++ b/packages/twig-to-php-parser/lib/twig-to-php-parser.php
@@ -229,26 +229,27 @@ function parse_include_path( $twig_include, $pattern_name, $data_name, $is_using
 	$brand_directory = 'CHILD_THEME_PATH';
 	$pattern_directory = '/template-parts/patterns/';
 	$start_name = substr( $pattern_name, 0, 2 );
+	$pattern_type = '';
 
-	if ( true === $is_using_plugin ) {
-		$pattern_directory = '/build/patterns/';
-		$key_name = strpos( $twig_include, '@larva' ) ? 'core_directory' : 'brand_directory';
-		$brand_directory = "\PMC\Larva\Config::get_instance()->get( '" . $key_name . "' )";
-	} else {
-		if ( strpos( $twig_include, '@larva' ) ) {
-			$brand_directory = 'PMC_CORE_PATH';
-		}
+	if ( strpos( $twig_include, '@larva' ) ) {
+		$brand_directory = 'PMC_CORE_PATH';
 	}
 
 	if ( 'c-' === $start_name ) {
-		$pattern_directory .= 'components';
+		$pattern_type = 'components';
 	} elseif ( 'o-' === $start_name ) {
-		$pattern_directory .= 'objects';
+		$pattern_type = 'objects';
 	} elseif ( '-' !== substr( $pattern_name, 1, 2 ) ) { // If there is no namespace, it is a module.
-		$pattern_directory .= 'modules';
+		$pattern_type = 'modules';
 	}
 
-	return "<?php \PMC::render_template( " . $brand_directory . " . '" . $pattern_directory . "/" . $pattern_name . ".php', $" . $data_name . ', true ); ?>';
+	if ( $is_using_plugin ) {
+		return "<?php \PMC\Larva\Pattern::get_instance()->render_pattern_template( '" . $pattern_type . '/' . $pattern_name . "', $" . $data_name . ", true ); ?>";
+	} else {
+		$pattern_partial_path = $pattern_directory . $pattern_type . '/' . $pattern_name;
+
+		return '<?php \PMC::render_template( ' . $brand_directory . " . '" . $pattern_partial_path  . ".php', $" . $data_name . ', true ); ?>';
+	}
 
 }
 


### PR DESCRIPTION
Update to use the `Pattern::render_pattern_template` method in the parser for themes using the pmc-plugin - only Indiewire.