### PR TITLE
Remove static assets route for larvaPatternsDir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [8.14.20-alpha] - 07-23-2020
+
+* larva - Fix to use single path to assets in Larva server.
+
 ## [8.14.19-alpha] - 07-23-2020
 
 * twig-to-php-parser - Update isUsingPlugin `include` path transformation to use new render_pattern_template method

--- a/packages/larva/lib/server.js
+++ b/packages/larva/lib/server.js
@@ -57,7 +57,6 @@ app.use( '/packages/' , express.static( path.join( appConfiguration.larvaPattern
 // collection for the nav will come from an object based on the directory structure
 
 if( appConfiguration.larvaPatternsDir ) {
-	app.use( '/assets' , express.static( path.join( __dirname, '../' ) ) );
 	patterns.larva.modules = getSubDirectoryNames( path.join( appConfiguration.larvaPatternsDir + '/modules' ) );
 	patterns.larva.objects = getSubDirectoryNames( path.join( appConfiguration.larvaPatternsDir + '/objects' ) );
 	patterns.larva.components = getSubDirectoryNames( path.join( appConfiguration.larvaPatternsDir + '/components' ) );
@@ -65,13 +64,14 @@ if( appConfiguration.larvaPatternsDir ) {
 }
 
 if( appConfiguration.projectPatternsDir ) {
-	app.use( '/assets' , express.static( path.join( appConfiguration.projectPatternsDir, '../../' ) ) );
 	patterns.project.modules = getSubDirectoryNames( path.join( appConfiguration.projectPatternsDir + '/modules' ) );
 	patterns.project.objects = getSubDirectoryNames( path.join( appConfiguration.projectPatternsDir + '/objects' ) );
 	patterns.project.components = getSubDirectoryNames( path.join( appConfiguration.projectPatternsDir + '/components' ) );
 	patterns.project.oneOffs = getSubDirectoryNames( path.join( appConfiguration.projectPatternsDir + '/one-offs' ) );
 	patterns.project.tests = getSubDirectoryNames( path.join( appConfiguration.projectPatternsDir + '/__tests__' ) );
 }
+
+app.use( '/assets' , express.static( path.join( appConfiguration.projectPatternsDir, '../../' ) ) );
 
 app.get( '/', function (req, res) {
 	req.params[ 'source' ] = 'larva';

--- a/packages/larva/lib/server.js
+++ b/packages/larva/lib/server.js
@@ -71,6 +71,7 @@ if( appConfiguration.projectPatternsDir ) {
 	patterns.project.tests = getSubDirectoryNames( path.join( appConfiguration.projectPatternsDir + '/__tests__' ) );
 }
 
+// appConfiguration.projectPatternsDir will be assets/src/patterns - move out to assets.
 app.use( '/assets' , express.static( path.join( appConfiguration.projectPatternsDir, '../../' ) ) );
 
 app.get( '/', function (req, res) {


### PR DESCRIPTION
We only need the one to projectPatternsDir - not to larvaPatternsDir.