### PR TITLE
Fix: Accessibility issues: Broken ARIA reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 * twig-to-php-parser - Add support for item['submodule'] in for include and mustache regex
+* larva-patterns - add condition to check before adding aria-labelledby attribute to o-nav
 
 ## [8.14.26-alpha] - 08-26-2020
 

--- a/packages/larva-patterns/objects/o-nav/o-nav.twig
+++ b/packages/larva-patterns/objects/o-nav/o-nav.twig
@@ -4,7 +4,7 @@
 		<h4 id="{{ o_nav_title_id_attr }}" class="o-nav__title {{ o_nav_title_classes }}">{{ o_nav_title_text }}</h4>
 	{% endif %}
 
-	<ul class="o-nav__list {{ o_nav_list_classes }}" aria-labelledby="{{ o_nav_title_id_attr }}">
+	<ul class="o-nav__list {{ o_nav_list_classes }}" {% if o_nav_title_id_attr %} aria-labelledby="{{ o_nav_title_id_attr }}" {% endif %}>
 		{% for item in o_nav_list_items %}
 			<li class="o-nav__list-item {{ o_nav_list_item_classes }}">
 				{% include "@larva/components/c-link/c-link.twig" with item %}


### PR DESCRIPTION
Fix: Accessibility issues: Broken ARIA reference by adding condition check before adding an empty aria-labelledby attribute to o-nav.

<img width="804" alt="Screenshot 2020-09-01 at 7 57 17 PM" src="https://user-images.githubusercontent.com/11607839/91977780-c78fc780-ed40-11ea-8969-32fce4cd1623.png">
