### PR TITLE
- Fix larva-patterns/modules/social-share/social-share.twig to use sq…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## unpublished
+* Fix larva-patterns/modules/social-share/social-share.twig to use square bracket notation for accessing submodule values
+
 ## 0.1.6 - 11-02-2020
 * Add aria-controls support for vlanding-video-card
 * Remove support for elseif in twig-to-php parser

--- a/packages/larva-patterns/modules/social-share/social-share.twig
+++ b/packages/larva-patterns/modules/social-share/social-share.twig
@@ -15,7 +15,7 @@
 
 		{% if social_share_secondary %}
 			<li data-collapsible-toggle>
-				<button  class="c-button {{ c_icon_plus.c_icon_link_classes }}" title="Show more sharing options" data-toggle>
+				<button  class="c-button {{ c_icon_plus['c_icon_link_classes'] }}" title="Show more sharing options" data-toggle>
 					{% include "@larva/components/c-icon/c-icon.twig" with c_icon_plus %}
 				</button>
 			</li>


### PR DESCRIPTION
…uare bracket notation for accessing submodule values