### PR TITLE
Tokens Form: Only copy token values that are changed from default

### DIFF
--- a/packages/site/src/components/TokenListItem.js
+++ b/packages/site/src/components/TokenListItem.js
@@ -74,9 +74,9 @@ export const TokenListItem = ({
 								be centrally managed from "Core Colors". Please
 								confirm this change.
 							</p>
-							<div class="ui two buttons">
+							<div className="ui two buttons">
 								<button
-									class="ui basic green button"
+									className="ui basic green button"
 									onClick={() => {
 										onClick(confirmingCoreColorChange);
 									}}
@@ -84,7 +84,7 @@ export const TokenListItem = ({
 									Confirm
 								</button>
 								<button
-									class="ui basic red button"
+									className="ui basic red button"
 									onClick={() => {
 										onClick(tokenData.value);
 									}}

--- a/packages/site/src/components/TokensView.js
+++ b/packages/site/src/components/TokensView.js
@@ -152,6 +152,9 @@ export const TokensView = () => {
 		})( tokens, defaultTokens );
 
 		const tokensOutput = {
+			imports: [
+				"../base/all.json"
+			],
 			props: diffedTokens,
 		};
 

--- a/packages/site/src/components/TokensView.js
+++ b/packages/site/src/components/TokensView.js
@@ -11,7 +11,7 @@ import {
 export const TokensView = () => {
 	let match = useRouteMatch();
 
-	const TOKENS_FETCH_URL = "https://raw.githubusercontent.com/penske-media-corp/pmc-larva/master/packages/larva-tokens/build/";
+	const TOKENS_FETCH_URL = "https://raw.githubusercontent.com/penske-media-corp/pmc-larva/feature/spy-tokens/packages/larva-tokens/build/";
 
 	const appActions = {
 		create: "create",

--- a/packages/site/src/components/TokensView.js
+++ b/packages/site/src/components/TokensView.js
@@ -11,6 +11,8 @@ import {
 export const TokensView = () => {
 	let match = useRouteMatch();
 
+	const TOKENS_FETCH_URL = "https://raw.githubusercontent.com/penske-media-corp/pmc-larva/master/packages/larva-tokens/build/";
+
 	const appActions = {
 		create: "create",
 		update: "update",
@@ -25,6 +27,7 @@ export const TokensView = () => {
 		undefined !== window.showSaveFilePicker;
 
 	const [tokens, setTokens] = useState({});
+	const [defaultTokens, setDefaultTokens] = useState({});
 	const [copied, setCopied] = useState(false);
 	const [copyText, setCopyText] = useState("");
 	const [canSaveFile] = useState(supportsshowSaveFilePicker);
@@ -87,7 +90,7 @@ export const TokensView = () => {
 				: selectedBrand.brand;
 
 		let url =
-			"https://raw.githubusercontent.com/penske-media-corp/pmc-larva/master/packages/larva-tokens/build/" +
+			TOKENS_FETCH_URL +
 			brand +
 			".raw.json";
 		let response = await fetch(url);
@@ -108,7 +111,25 @@ export const TokensView = () => {
 
 		setCoreColorTokens(sortedColorTokens);
 		setTokens(sortedTokens);
+
+		const fetchedDefaultTokens = ( async (e) => {
+			if ( 'default' === brand ) {
+				return sortedTokens;
+			} else {
+				let url = TOKENS_FETCH_URL + "/default.raw.json";
+				let response = await fetch(url);
+				let json = await response.json();
+				let tokens = await json.props;
+
+				return tokens;
+			}
+		})();
+
+		// Save unchanged tokens so we can tell what is
+		// different from the original
+		setDefaultTokens( await fetchedDefaultTokens);
 	};
+
 
 	/**
 	 * Save JSON to file for browsers that support it, and fallback to
@@ -117,8 +138,21 @@ export const TokensView = () => {
 	 * @see https://developer.mozilla.org/en-US/docs/Web/API/window/showSaveFilePicker
 	 */
 	const saveJsonToFile = async () => {
+
+		const diffedTokens =( ( changed, reference ) => {
+			const updatedTokenKeys = Object.keys( changed ).filter( key => {
+				return changed[key].value !== reference[key].value;
+			});
+
+			return updatedTokenKeys.reduce( ( acc, curr ) => {
+				acc[curr] = { ...changed[curr] };
+				return acc;
+			}, {} );
+
+		})( tokens, defaultTokens );
+
 		const tokensOutput = {
-			props: tokens,
+			props: diffedTokens,
 		};
 
 		if (canSaveFile) {

--- a/packages/site/src/components/TokensView.js
+++ b/packages/site/src/components/TokensView.js
@@ -11,7 +11,7 @@ import {
 export const TokensView = () => {
 	let match = useRouteMatch();
 
-	const TOKENS_FETCH_URL = "https://raw.githubusercontent.com/penske-media-corp/pmc-larva/feature/spy-tokens/packages/larva-tokens/build/";
+	const TOKENS_FETCH_URL = "https://raw.githubusercontent.com/penske-media-corp/pmc-larva/master/packages/larva-tokens/build/";
 
 	const appActions = {
 		create: "create",

--- a/packages/site/src/components/TokensView.js
+++ b/packages/site/src/components/TokensView.js
@@ -112,9 +112,11 @@ export const TokensView = () => {
 		setCoreColorTokens(sortedColorTokens);
 		setTokens(sortedTokens);
 
-		const fetchedDefaultTokens = ( async (e) => {
+		const initialDefaultTokens = ( async (e) => {
 			if ( 'default' === brand ) {
-				return sortedTokens;
+
+				// Deep clone the object since we are checking equivalence later.
+				return JSON.parse( JSON.stringify( sortedTokens ) );
 			} else {
 				let url = TOKENS_FETCH_URL + "/default.raw.json";
 				let response = await fetch(url);
@@ -127,7 +129,7 @@ export const TokensView = () => {
 
 		// Save unchanged tokens so we can tell what is
 		// different from the original
-		setDefaultTokens( await fetchedDefaultTokens);
+		setDefaultTokens( await initialDefaultTokens);
 	};
 
 
@@ -139,7 +141,7 @@ export const TokensView = () => {
 	 */
 	const saveJsonToFile = async () => {
 
-		const diffedTokens =( ( changed, reference ) => {
+		const diffedTokens = ( ( changed, reference ) => {
 			const updatedTokenKeys = Object.keys( changed ).filter( key => {
 				return changed[key].value !== reference[key].value;
 			});
@@ -155,7 +157,7 @@ export const TokensView = () => {
 			imports: [
 				"../base/all.json"
 			],
-			props: diffedTokens,
+			props: { ... diffedTokens },
 		};
 
 		if (canSaveFile) {

--- a/packages/site/src/components/TokensView.js
+++ b/packages/site/src/components/TokensView.js
@@ -11,7 +11,8 @@ import {
 export const TokensView = () => {
 	let match = useRouteMatch();
 
-	const TOKENS_FETCH_URL = "https://raw.githubusercontent.com/penske-media-corp/pmc-larva/master/packages/larva-tokens/build/";
+	const TOKENS_FETCH_URL =
+		"https://raw.githubusercontent.com/penske-media-corp/pmc-larva/master/packages/larva-tokens/build/";
 
 	const appActions = {
 		create: "create",
@@ -89,10 +90,7 @@ export const TokensView = () => {
 				? "default"
 				: selectedBrand.brand;
 
-		let url =
-			TOKENS_FETCH_URL +
-			brand +
-			".raw.json";
+		let url = TOKENS_FETCH_URL + brand + ".raw.json";
 		let response = await fetch(url);
 		let json = await response.json();
 		let tokens = await json.props;
@@ -112,11 +110,10 @@ export const TokensView = () => {
 		setCoreColorTokens(sortedColorTokens);
 		setTokens(sortedTokens);
 
-		const initialDefaultTokens = ( async (e) => {
-			if ( 'default' === brand ) {
-
+		const initialDefaultTokens = (async (e) => {
+			if ("default" === brand) {
 				// Deep clone the object since we are checking equivalence later.
-				return JSON.parse( JSON.stringify( sortedTokens ) );
+				return JSON.parse(JSON.stringify(sortedTokens));
 			} else {
 				let url = TOKENS_FETCH_URL + "/default.raw.json";
 				let response = await fetch(url);
@@ -129,9 +126,8 @@ export const TokensView = () => {
 
 		// Save unchanged tokens so we can tell what is
 		// different from the original
-		setDefaultTokens( await initialDefaultTokens);
+		setDefaultTokens(await initialDefaultTokens);
 	};
-
 
 	/**
 	 * Save JSON to file for browsers that support it, and fallback to
@@ -140,24 +136,26 @@ export const TokensView = () => {
 	 * @see https://developer.mozilla.org/en-US/docs/Web/API/window/showSaveFilePicker
 	 */
 	const saveJsonToFile = async () => {
+		const diffedTokens = ((changed, reference) => {
+			const updatedTokenKeys = Object.keys(changed).filter((key) => {
+				// If changed key is not present in the reference, then it
+				// is a custom token, and we should keep it
+				if (undefined === reference[key]) {
+					return true;
+				}
 
-		const diffedTokens = ( ( changed, reference ) => {
-			const updatedTokenKeys = Object.keys( changed ).filter( key => {
 				return changed[key].value !== reference[key].value;
 			});
 
-			return updatedTokenKeys.reduce( ( acc, curr ) => {
+			return updatedTokenKeys.reduce((acc, curr) => {
 				acc[curr] = { ...changed[curr] };
 				return acc;
-			}, {} );
-
-		})( tokens, defaultTokens );
+			}, {});
+		})(tokens, defaultTokens);
 
 		const tokensOutput = {
-			imports: [
-				"../base/all.json"
-			],
-			props: { ... diffedTokens },
+			imports: ["../base/all.json"],
+			props: { ...diffedTokens },
 		};
 
 		if (canSaveFile) {

--- a/packages/site/src/data.js
+++ b/packages/site/src/data.js
@@ -8,6 +8,7 @@ export const brands = [
 	"rollingstone",
 	"sheknows",
 	"sportico",
+	"spy",
 	"thr",
 	"variety-vip",
 	"variety",


### PR DESCRIPTION
In order to manage the values of default tokens in one place, the tokens form should only copy the token values that have changed.

To check this functionality:
1. Navigate to the branch deployment here: https://pmc-larva-git-fix-tokens-diff-penske-media-corp.vercel.app
2. Select "Design Tokens"
2. Create tokens for a new brand with any name.
3. Change the value of any token on the right
4. Click "Save JSON to file". 
5. In the file, ensure there is only one token in the "props" key.