### PR TITLE
PMCP-3027: Allow o-icon-button to be used in o-social-list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unpublished
+* Allow o-icon-button to be used in o-social-list.
+
 ## 0.2.1 - 05-11-2021
 * larva-tokens - Add Sourcing Journal (SJ) design tokens.
 * larva-tokens - Adding WWD redesign as wwd-2021 to tokens.

--- a/packages/larva-patterns/objects/o-social-list/o-social-list.twig
+++ b/packages/larva-patterns/objects/o-social-list/o-social-list.twig
@@ -5,7 +5,11 @@
 >
 	{% for item in o_social_list_icons %}
 		<li class="o-social-list__item {{ o_social_list_item_classes }}">
-			{% include "@larva/components/c-icon/c-icon.twig" with item %}
+			{% if o_social_list_is_icon_button %}
+				{% include "@larva/objects/o-icon-button/o-icon-button.twig" with item %}
+			{% else %}
+				{% include "@larva/components/c-icon/c-icon.twig" with item %}
+			{% endif %}
 		</li>
 	{% endfor %}
 </ul>


### PR DESCRIPTION
### Doneness Checklist:

Pre-release # (or n/a):

- [x] Updated changelog with summary of changes under `Unpublished` section
- [ ] `npm run prod` in this repo outputs no changes
- [ ] Tested changes in pmc-spark [via a pre-release](https://confluence.pmcdev.io/x/XhOeAw):
- - [ ] If changes to build tools: npm scripts `prod`, `lint`, and `dev` scripts run as expected
- - [ ] If changes to Larva server: Static site generates as expected in a theme  (avail. on a URL {brand}.stg.larva.pmcdev.io)