### PR TITLE
logic for alerting on console when there is an error

### DIFF
--- a/packages/larva/lib/writeJson.js
+++ b/packages/larva/lib/writeJson.js
@@ -41,7 +41,11 @@ module.exports = function writeJson( patternConfig, fromLarva = false ) {
 
 			if ( hasChanged ) {
 				writeJsonToFile( jsonDestPath, moduleData );
-				console.log( chalk.green.bold( `Wrote JSON for ${moduleName}.${variant}` ) );
+				if ( moduleData.error ) {
+					console.log( chalk.red.bold( `Wrote JSON for ${moduleName}.${variant} with Errors. Please fix the errors before proceeding.` ) );
+				} else {
+					console.log( chalk.green.bold( `Wrote JSON for ${moduleName}.${variant}` ) );
+				}
 			} else {
 				console.log( chalk.grey( `No updates in ${moduleName}.${variant}` ) );
 			}


### PR DESCRIPTION
#### What issue this change is trying to address?
 - The developer is not explicitly alerted when there are errors in a pattern type under development. While the error information is written to the JSON file, it may get accidentally overlooked by a developer especially when working on a complex module. 
#### What this change will do: 
 - This change will explicitly alert the developer when an error is observed. 
#### In what circumstances will this be particularly helpful:
 - I believe this will be particularly helpful when a developer is working on a complex module. In such a case, an accidental mistake in any of the pattern types under development will be explicitly visible to the developer and will save time. 
#### Visible behavior after this change (Example):
 - Normal Update
![Screenshot from 2021-08-14 10-20-21](https://user-images.githubusercontent.com/1982786/129449391-e84ab175-4e44-49da-a11a-c0c4483cdc9b.png)
 - Update with Errors
![Screenshot from 2021-08-14 10-20-52](https://user-images.githubusercontent.com/1982786/129449407-aafd45ba-3061-44af-99eb-1375ebdc229b.png)

Thanks!

### Doneness Checklist:

Pre-release # (or n/a):

- [ ] Updated root CHANGELOG.md with summary of changes under `Unpublished` section
- [ ] `npm run prod` in this repo outputs expected changes (excepting the issue with re-ordered partials in larva-css algorithms partials - see [LRVA-1885](https://jira.pmcdev.io/browse/LRVA-1885))
- [ ] If changes to build scripts or the Node.js server, tested changes in pmc-spark [via a pre-release](https://confluence.pmcdev.io/x/XhOeAw)
- - [ ] If changes to build tools: npm scripts `prod`, `lint`, and `dev` scripts run as expected
- - [ ] If changes to Larva server: Static site generates as expected in a theme  (avail. on a URL {brand}.stg.larva.pmcdev.io)