### PR TITLE
Update Larva pattern to match block's options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## Unpublished
+* larva-patterns - Fix `story` module's use of `c_dek` component.
 
 ## 0.3.3 - 08-09-2021
 * larva-patterns - Add `carousel-slider` module.

--- a/packages/larva-patterns/modules/story/story.twig
+++ b/packages/larva-patterns/modules/story/story.twig
@@ -14,7 +14,10 @@
 		<div class="{{ story_grid_secondary_classes }} // lrv-u-flex lrv-u-flex-direction-column lrv-u-height-100p lrv-u-justify-content-center">
 
 			{% include "@larva/components/c-title/c-title.twig" with c_title %}
-			{% include "@larva/components/c-dek/c-dek.twig" with c_dek %}
+
+			{% if c_dek %}
+				{% include "@larva/components/c-dek/c-dek.twig" with c_dek %}
+			{% endif %}
 
 			<ul class="lrv-u-flex lrv-u-order-n1 lrv-a-unstyle-list lrv-a-space-children-horizontal lrv-a-space-children--050 lrv-u-margin-b-050 u-letter-spacing-012 // {{ story_links_classes }}">
 


### PR DESCRIPTION
Story Block Engine allows dek to be hidden, in which case the `c_dek` data node is set to `false`. Currently, this produces a fatal error due to the missing check.

### Doneness Checklist:

Pre-release # (or n/a):

- [x] Updated root CHANGELOG.md with summary of changes under `Unpublished` section
- [x] `npm run prod` in this repo outputs expected changes (excepting the issue with re-ordered partials in larva-css algorithms partials - see [LRVA-1885](https://jira.pmcdev.io/browse/LRVA-1885))
- [ ] If changes to build scripts or the Node.js server, tested changes in pmc-spark [via a pre-release](https://confluence.pmcdev.io/x/XhOeAw)
- - [ ] If changes to build tools: npm scripts `prod`, `lint`, and `dev` scripts run as expected
- - [ ] If changes to Larva server: Static site generates as expected in a theme  (avail. on a URL {brand}.stg.larva.pmcdev.io)