### PR TITLE
Add separator variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## Unpublished
 * larva-patterns - Fix `story` module's use of `c_dek` component.
+* larva-patterns - Add additional separator styles.
 
 ## 0.3.3 - 08-09-2021
 * larva-patterns - Add `carousel-slider` module.

--- a/packages/larva-patterns/modules/separator/separator.thick.js
+++ b/packages/larva-patterns/modules/separator/separator.thick.js
@@ -1,0 +1,7 @@
+const clonedeep = require( 'lodash.clonedeep' );
+
+const separator = clonedeep( require( './separator.prototype' ) );
+
+separator.separator_classes = 'lrv-u-border-a-3';
+
+module.exports = separator;

--- a/packages/larva-patterns/modules/separator/separator.wide-thick.js
+++ b/packages/larva-patterns/modules/separator/separator.wide-thick.js
@@ -1,0 +1,7 @@
+const clonedeep = require( 'lodash.clonedeep' );
+
+const separator = clonedeep( require( './separator.wide' ) );
+
+separator.separator_classes = 'lrv-u-margin-tb-1 lrv-u-border-a-3 lrv-u-margin-lr-2 lrv-u-margin-lr-4@desktop';
+
+module.exports = separator;

--- a/packages/larva-patterns/modules/separator/separator.wide.js
+++ b/packages/larva-patterns/modules/separator/separator.wide.js
@@ -1,0 +1,7 @@
+const clonedeep = require( 'lodash.clonedeep' );
+
+const separator = clonedeep( require( './separator.prototype' ) );
+
+separator.separator_classes = 'lrv-u-margin-tb-1 lrv-u-border-a-1 lrv-u-margin-lr-2 lrv-u-margin-lr-4@desktop';
+
+module.exports = separator;


### PR DESCRIPTION
Introduces thicker separator variants, as well as porting the `wide` variant from IndieWire.

### Doneness Checklist:

Pre-release # (or n/a):

- [x] Updated root CHANGELOG.md with summary of changes under `Unpublished` section
- [x] `npm run prod` in this repo outputs expected changes (excepting the issue with re-ordered partials in larva-css algorithms partials - see [LRVA-1885](https://jira.pmcdev.io/browse/LRVA-1885))
- [ ] If changes to build scripts or the Node.js server, tested changes in pmc-spark [via a pre-release](https://confluence.pmcdev.io/x/XhOeAw)
- - [ ] If changes to build tools: npm scripts `prod`, `lint`, and `dev` scripts run as expected
- - [ ] If changes to Larva server: Static site generates as expected in a theme  (avail. on a URL {brand}.stg.larva.pmcdev.io)