### PR TITLE
Add variants for remaining H# tags

### DIFF
--- a/packages/larva-patterns/modules/heading/heading.h1.js
+++ b/packages/larva-patterns/modules/heading/heading.h1.js
@@ -2,7 +2,7 @@ const clonedeep = require( 'lodash.clonedeep' );
 
 const heading = clonedeep( require( './heading.prototype' ) );
 
-heading.heading_classes = 'lrv-a-font-primary-xl';
+heading.heading_typography_class = 'lrv-a-font-primary-xl';
 heading.heading_level_text = '1';
 
 module.exports = heading;

--- a/packages/larva-patterns/modules/heading/heading.h2.js
+++ b/packages/larva-patterns/modules/heading/heading.h2.js
@@ -2,7 +2,7 @@ const clonedeep = require( 'lodash.clonedeep' );
 
 const heading = clonedeep( require( './heading.prototype' ) );
 
-heading.heading_classes = 'lrv-a-font-accent-l';
+heading.heading_typography_class = 'lrv-a-font-accent-l';
 heading.heading_level_text = '2';
 
 module.exports = heading;

--- a/packages/larva-patterns/modules/heading/heading.h3.js
+++ b/packages/larva-patterns/modules/heading/heading.h3.js
@@ -2,7 +2,7 @@ const clonedeep = require( 'lodash.clonedeep' );
 
 const heading = clonedeep( require( './heading.prototype' ) );
 
-heading.heading_classes = 'lrv-a-font-secondary-l';
+heading.heading_typography_class = 'lrv-a-font-secondary-l';
 heading.heading_level_text = '3';
 
 module.exports = heading;

--- a/packages/larva-patterns/modules/heading/heading.h4.js
+++ b/packages/larva-patterns/modules/heading/heading.h4.js
@@ -1,0 +1,7 @@
+const clonedeep = require( 'lodash.clonedeep' );
+
+const heading = clonedeep( require( './heading.prototype' ) );
+
+heading.heading_level_text = '4';
+
+module.exports = heading;

--- a/packages/larva-patterns/modules/heading/heading.h5.js
+++ b/packages/larva-patterns/modules/heading/heading.h5.js
@@ -1,0 +1,7 @@
+const clonedeep = require( 'lodash.clonedeep' );
+
+const heading = clonedeep( require( './heading.prototype' ) );
+
+heading.heading_level_text = '5';
+
+module.exports = heading;

--- a/packages/larva-patterns/modules/heading/heading.h6.js
+++ b/packages/larva-patterns/modules/heading/heading.h6.js
@@ -1,0 +1,7 @@
+const clonedeep = require( 'lodash.clonedeep' );
+
+const heading = clonedeep( require( './heading.prototype' ) );
+
+heading.heading_level_text = '6';
+
+module.exports = heading;

--- a/packages/larva-patterns/modules/heading/heading.prototype.js
+++ b/packages/larva-patterns/modules/heading/heading.prototype.js
@@ -1,8 +1,9 @@
 module.exports = {
 	heading_level_text: '3',
-	heading_classes: 'lrv-a-font-primary-m',
+	heading_classes: '',
 	heading_color_class: '',
 	heading_text_align_class: '',
+	heading_typography_class: 'lrv-a-font-primary-m',
 	heading_background_color_class: '',
 	heading_markup: 'Heading Text'
 };

--- a/packages/larva-patterns/modules/heading/heading.twig
+++ b/packages/larva-patterns/modules/heading/heading.twig
@@ -1,1 +1,1 @@
-<h{{ heading_level_text }} class="heading larva // {{ heading_classes }} {{ heading_color_class }} {{ heading_background_color_class }} {{ heading_text_align_class }}">{{ heading_markup }}</h{{ heading_level_text }}>
+<h{{ heading_level_text }} class="heading larva // {{ heading_classes }} {{ heading_typography_class }} {{ heading_color_class }} {{ heading_background_color_class }} {{ heading_text_align_class }}">{{ heading_markup }}</h{{ heading_level_text }}>


### PR DESCRIPTION
WWD styles each of the H# tags differently, requiring the Gutenberg block to
have access to variants for each heading level.

### Doneness Checklist:

Pre-release # (or n/a):

- [ ] Updated root CHANGELOG.md with summary of changes under `Unpublished` section
- [ ] `npm run prod` in this repo outputs expected changes (excepting the issue with re-ordered partials in larva-css algorithms partials - see [LRVA-1885](https://jira.pmcdev.io/browse/LRVA-1885))
- [ ] If changes to build scripts or the Node.js server, tested changes in pmc-spark [via a pre-release](https://confluence.pmcdev.io/x/XhOeAw)
- - [ ] If changes to build tools: npm scripts `prod`, `lint`, and `dev` scripts run as expected
- - [ ] If changes to Larva server: Static site generates as expected in a theme  (avail. on a URL {brand}.stg.larva.pmcdev.io)