### PR TITLE
Better error handling when there are json errors

### DIFF
--- a/packages/larva/lib/writeJson.js
+++ b/packages/larva/lib/writeJson.js
@@ -6,6 +6,7 @@ const getPatternData = require( './utils/getPatternData' );
 const getModuleNamesFromDirectory = require( './utils/getModuleNamesFromDirectory' );
 const getPatternVariants = require( './utils/getPatternVariants' );
 const writeJsonToFile = require( './utils/writeJsonToFile' );
+const { exit } = require('process');
 
 // The fromLarva flag can come from CLI argument
 module.exports = function writeJson( patternConfig, fromLarva = false ) {
@@ -26,6 +27,15 @@ module.exports = function writeJson( patternConfig, fromLarva = false ) {
 				name: moduleName,
 				variant: variant
 			} );
+
+			if ( moduleData.error ) {
+				console.warn(
+					chalk.red( moduleData.error.stack )
+				);
+
+				// Terminate process at error.
+				exit();
+			}
 
 			const jsonDestPath = path.resolve( patternConfig.projectPatternsDir, '../../build/json/modules/' + moduleName + '.' + variant + '.json' );
 


### PR DESCRIPTION
When there are JSON errors in the prototype, exit the process and output the error.

The current behavior prints a generic error to the JSON and on subsequent runs, the error is not evident as the file has not changed.

<!-- Add a summary of your changes here -->

### Doneness Checklist:

Pre-release # (or n/a):

- [ ] Updated root CHANGELOG.md with summary of changes under `Unpublished` section
- [ ] `npm run prod` in this repo outputs expected changes (excepting the issue with re-ordered partials in larva-css algorithms partials - see [LRVA-1885](https://jira.pmcdev.io/browse/LRVA-1885))
- [ ] If changes to build scripts or the Node.js server, tested changes in pmc-spark [via a pre-release](https://confluence.pmcdev.io/x/XhOeAw)
- - [ ] If changes to build tools: npm scripts `prod`, `lint`, and `dev` scripts run as expected
- - [ ] If changes to Larva server: Static site generates as expected in a theme  (avail. on a URL {brand}.stg.larva.pmcdev.io)