### PR TITLE
GUT-106: Copy webfonts from theme when building static site

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unpublished
-* larva - Support configuration for copying local webfonts from the theme to the static sites
+* larva - Support configuration for copying local assets from the theme to the static sites
 * larva-patterns - Add template level test with hub modules
 
 ## 0.3.8 - 10-19-2021

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unpublished
+* larva - Support configuration for copying local webfonts from the theme to the static sites
+* larva-patterns - Add template level test with hub modules
 
 ## 0.3.8 - 10-19-2021
 * larva-tokens - Add Robb Report tokens

--- a/packages/larva-patterns/__tests__/hub/hub.html
+++ b/packages/larva-patterns/__tests__/hub/hub.html
@@ -1,0 +1,19 @@
+<div class="lrv-a-wrapper">
+	{% include "modules/heading/heading.twig" with heading_h1 %}
+
+	{% include "modules/paragraph/paragraph.twig" with paragraph %}
+
+	{% include "modules/button/button.twig" with button %}
+
+	{% include "modules/carousel-grid/carousel-grid.twig" with carousel_grid %}
+
+	{% include "modules/separator/separator.twig" with separator %}
+
+	{% include "modules/carousel-slider/carousel-slider.twig" with carousel_slider %}
+
+	{% include "modules/heading/heading.twig" with heading_h3 %}
+
+	{% include "modules/story-grid/story-grid.twig" with story_grid %}
+
+	{% include "modules/story-grid/story-grid.twig" with story_grid %}
+</div>

--- a/packages/larva-patterns/__tests__/hub/hub.prototype.js
+++ b/packages/larva-patterns/__tests__/hub/hub.prototype.js
@@ -1,0 +1,23 @@
+const clonedeep = require( 'lodash.clonedeep' );
+
+const carousel_grid = clonedeep( require( '../../modules/carousel-grid/carousel-grid.prototype' ) );
+const carousel_slider = clonedeep( require( '../../modules/carousel-slider/carousel-slider.prototype' ) );
+const story_grid = clonedeep( require( '../../modules/story-grid/story-grid.prototype' ) );
+const heading_h1 = clonedeep( require( '../../modules/heading/heading.h1' ) );
+const heading_h3 = clonedeep( require( '../../modules/heading/heading.h3' ) );
+const story = clonedeep( require( '../../modules/story/story.prototype' ) );
+const button = clonedeep( require( '../../modules/button/button.prototype' ) );
+const paragraph = clonedeep( require( '../../modules/paragraph/paragraph.prototype' ) );
+const separator = clonedeep( require( '../../modules/separator/separator.prototype' ) );
+
+module.exports = {
+	carousel_grid,
+	carousel_slider,
+	story_grid,
+	heading_h1,
+	heading_h3,
+	paragraph,
+	story,
+	button,
+	separator
+};

--- a/packages/larva/lib/generateStatic.js
+++ b/packages/larva/lib/generateStatic.js
@@ -8,7 +8,7 @@ const getAppConfiguration = require( './utils/getAppConfiguration' );
 const copySyncHelper = require( './utils/copySyncHelper' );
 
 const assetsConfig = getAppConfiguration( 'assets' );
-const webfontsConfig = getAppConfiguration( 'webfonts' );
+const themeAssetsConfig = getAppConfiguration( 'themeAssets' );
 
 /**
  * Generate Static HTML
@@ -67,7 +67,15 @@ module.exports = function generateStatic( routesArr, buildPath, done, urlBase = 
 	});
 
 	copySyncHelper( publicAssetsSrc, publicAssetsDest );
-	copySyncHelper( webfontsConfig.path, path.join( publicAssetsDest, 'webfonts' ) );
+
+	const themeAssetKeys = Object.keys( themeAssetsConfig );
+
+	themeAssetKeys.forEach( key => {
+		const src = themeAssetsConfig[key];
+		const dest = path.join( buildPath, `../assets/theme/${key}` );
+
+		copySyncHelper( src, dest );
+	});
 
 	// Build the site.
 	// Cycle through the list of routes and write the response

--- a/packages/larva/lib/generateStatic.js
+++ b/packages/larva/lib/generateStatic.js
@@ -8,6 +8,7 @@ const getAppConfiguration = require( './utils/getAppConfiguration' );
 const copySyncHelper = require( './utils/copySyncHelper' );
 
 const assetsConfig = getAppConfiguration( 'assets' );
+const webfontsConfig = getAppConfiguration( 'webfonts' );
 
 /**
  * Generate Static HTML
@@ -50,11 +51,10 @@ module.exports = function generateStatic( routesArr, buildPath, done, urlBase = 
 	})();
 	const publicAssetsDest = path.join( buildPath, '../assets/public' );
 
-	// Could do a globby here, but this won't change much so it might be okay.
 	const builtAssets = [
 		'js',
 		'css',
-		'tokens', // TODO: only copy tokens for the brand
+		'tokens',
 		'images',
 		'svg'
 	];
@@ -67,6 +67,7 @@ module.exports = function generateStatic( routesArr, buildPath, done, urlBase = 
 	});
 
 	copySyncHelper( publicAssetsSrc, publicAssetsDest );
+	copySyncHelper( webfontsConfig.path, path.join( publicAssetsDest, 'webfonts' ) );
 
 	// Build the site.
 	// Cycle through the list of routes and write the response

--- a/packages/larva/lib/server.js
+++ b/packages/larva/lib/server.js
@@ -23,6 +23,7 @@ const app = express();
 const patternConfig = getAppConfiguration( 'patterns' );
 const brandConfig = getAppConfiguration( 'brand' );
 const assetsConfig = getAppConfiguration( 'assets' );
+const webfontsConfig = getAppConfiguration( 'webfonts' );
 const twigPaths = getPatternPathsToLoad( patternConfig );
 
 let loader = new TwingLoaderFilesystem( twigPaths );
@@ -83,7 +84,11 @@ if ( fs.existsSync( assetsConfig.path ) ) {
 	app.use( '/assets' , express.static( assetsConfig.path ) );
 }
 
-app.get( '/:source?/css', function (req, res) {
+if ( fs.existsSync( webfontsConfig.path ) ) {
+	app.use( '/assets/public/webfonts' , express.static( webfontsConfig.path ) );
+}
+
+app.use( '/:source?/css', function (req, res) {
 
 	/**
 	 * Generate Larva CSS Docs

--- a/packages/larva/lib/server.js
+++ b/packages/larva/lib/server.js
@@ -23,7 +23,7 @@ const app = express();
 const patternConfig = getAppConfiguration( 'patterns' );
 const brandConfig = getAppConfiguration( 'brand' );
 const assetsConfig = getAppConfiguration( 'assets' );
-const webfontsConfig = getAppConfiguration( 'webfonts' );
+const themeAssetsConfig = getAppConfiguration( 'themeAssets' );
 const twigPaths = getPatternPathsToLoad( patternConfig );
 
 let loader = new TwingLoaderFilesystem( twigPaths );
@@ -84,9 +84,12 @@ if ( fs.existsSync( assetsConfig.path ) ) {
 	app.use( '/assets' , express.static( assetsConfig.path ) );
 }
 
-if ( fs.existsSync( webfontsConfig.path ) ) {
-	app.use( '/assets/public/webfonts' , express.static( webfontsConfig.path ) );
-}
+// Expose any theme directories with assets in the express server
+const themeAssetKeys = Object.keys( themeAssetsConfig );
+
+themeAssetKeys.forEach( key => {
+	app.use( '/assets/theme/' + key , express.static( themeAssetsConfig[key] ) );
+});
 
 app.use( '/:source?/css', function (req, res) {
 

--- a/packages/larva/lib/utils/getAppConfiguration.js
+++ b/packages/larva/lib/utils/getAppConfiguration.js
@@ -50,7 +50,11 @@ const defaultConfig = {
 
 			return path.resolve( './node_modules/@penskemediacorp/larva' );
 		})(),
-	}
+	},
+
+	webfonts: {
+		path: path.resolve( './src/fonts' )
+	},
 };
 
 module.exports = function getAppConfiguration( key, usePackageDefault = true ) {

--- a/packages/larva/lib/utils/getAppConfiguration.js
+++ b/packages/larva/lib/utils/getAppConfiguration.js
@@ -49,7 +49,7 @@ const defaultConfig = {
 			}
 
 			return path.resolve( './node_modules/@penskemediacorp/larva' );
-		})()
+		})(),
 	}
 };
 

--- a/packages/larva/lib/utils/getAppConfiguration.js
+++ b/packages/larva/lib/utils/getAppConfiguration.js
@@ -52,9 +52,7 @@ const defaultConfig = {
 		})(),
 	},
 
-	webfonts: {
-		path: path.resolve( './src/fonts' )
-	},
+	themeAssets: {},
 };
 
 module.exports = function getAppConfiguration( key, usePackageDefault = true ) {

--- a/packages/larva/scripts/build-html.js
+++ b/packages/larva/scripts/build-html.js
@@ -32,7 +32,16 @@ const staticPaths = [
 	'',
 ];
 
-staticPaths.forEach( p => routesArr.push( p ) );
+staticPaths.forEach( p => {
+	// Only build these paths for the larva source.
+	if ( p === 'style-guide' || p === 'css' ) {
+		if ( 'larva' !== source ) {
+			return;
+		}
+	}
+
+	routesArr.push( p )
+});
 
 generateStatic( routesArr, buildPath, ( message ) => {
 


### PR DESCRIPTION
<!-- Add a summary of your changes here -->
Add configuration to support copying local webfont files to the /assets/public so that they work on the static sites.

Corresponding documentation here: https://confluence.pmcdev.io/x/JQqeAw
Example static style guide with working local webfonts here: https://robbreport.stg.larva.pmcdev.io/larva/style-guide/

Additionally, add a static version of the hub modules for quick visibility and future regression testing: https://pmc-larva-ncscbugnd-penske-media-corp.vercel.app/larva/__tests__/hub/

### Doneness Checklist:

Pre-release # (or n/a): 0.3.9-develop.3+7ba1cc94 tested on RobbReport theme.

- [x] Updated root CHANGELOG.md with summary of changes under `Unpublished` section
- [x] `npm run prod` in this repo outputs expected changes (excepting the issue with re-ordered partials in larva-css algorithms partials - see [LRVA-1885](https://jira.pmcdev.io/browse/LRVA-1885))
- [x] If changes to build scripts or the Node.js server, tested changes in pmc-spark [via a pre-release](https://confluence.pmcdev.io/x/XhOeAw)
- - [ ] If changes to build tools: npm scripts `prod`, `lint`, and `dev` scripts run as expected
- - [x] If changes to Larva server: Static site generates as expected in a theme  (avail. on a URL {brand}.stg.larva.pmcdev.io)