### PR TITLE
Add update-larva script to init log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unpublished
+* Add update-larva command to list of scripts in init log message
 
 ## 0.3.11 - 11-11-2021
 * larva-tokens - Update VY tokens with additional colors and typography

--- a/packages/larva/scripts/init.js
+++ b/packages/larva/scripts/init.js
@@ -12,9 +12,10 @@ console.log(
 );
 
 console.log( `
-"larva": "larva server --watch src -e twig,js,html",
-"write-json": "larva write-json",
-"parser": "./node_modules/.bin/twig-to-php-parser",
 "backstop": "backstop --config=node_modules/@penskemediacorp/backstopjs-config",
-"build-html": "larva build-html"
+"build-html": "larva build-html",
+"larva": "larva server --watch src -e twig,js,html",
+"parser": "./node_modules/.bin/twig-to-php-parser",
+"update-larva": "npm install @penskemediacorp/larva@latest",
+"write-json": "larva write-json"
 ` );


### PR DESCRIPTION
Add script command for _update-larva_ to list of commands in init log message.

### Doneness Checklist:

Pre-release # (or n/a):

- [x] Updated root CHANGELOG.md with summary of changes under `Unpublished` section
- [ ] `npm run prod` in this repo outputs expected changes (excepting the issue with re-ordered partials in larva-css algorithms partials - see [LRVA-1885](https://jira.pmcdev.io/browse/LRVA-1885))
- [ ] If changes to build scripts or the Node.js server, tested changes in pmc-spark [via a pre-release](https://confluence.pmcdev.io/x/XhOeAw)
- - [ ] If changes to build tools: npm scripts `prod`, `lint`, and `dev` scripts run as expected
- - [ ] If changes to Larva server: Static site generates as expected in a theme  (avail. on a URL {brand}.stg.larva.pmcdev.io)