### PR TITLE
Updates changelog for 0.5.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unpublished
+
+## 0.5.2 - 02-15-2022
 * larva-tokens - Added Rollingstone 2022 tokens
 
 ## 0.5.1 - 02-09-2022


### PR DESCRIPTION
Update CHANGELOG for 0.5.2 release.

### Doneness Checklist:

Pre-release # (or n/a):

- [x] Updated root CHANGELOG.md with summary of changes under `Unpublished` section
- [ ] Ran the visual regression tests manually (see [the README](https://github.com/penske-media-corp/pmc-larva#running-visual-regression-tests) for details)
- [ ] `npm run prod` in this repo outputs expected changes (excepting the issue with re-ordered partials in larva-css algorithms partials - see [LRVA-1885](https://jira.pmcdev.io/browse/LRVA-1885))
- [ ] If changes to build scripts or the Node.js server, tested changes in pmc-spark [via a pre-release](https://confluence.pmcdev.io/x/XhOeAw)
- - If changes to build tools: npm scripts `prod`, `lint`, and `dev` scripts run as expected
- - If changes to Larva server: Static site generates as expected in a theme  (avail. on a URL {brand}.stg.larva.pmcdev.io)