### PR TITLE
Update button module to support Gutenberg's width controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unpublished
+* larva-patterns: Add width class to button module
 
 ## 0.5.2 - 02-15-2022
 * larva-tokens - Added Rollingstone 2022 tokens

--- a/packages/larva-patterns/modules/button/button.prototype.js
+++ b/packages/larva-patterns/modules/button/button.prototype.js
@@ -5,4 +5,5 @@ module.exports = {
 	button_background_color_class: 'lrv-u-background-color-brand-primary',
 	button_color_class: 'lrv-u-color-white',
 	button_typography_class: '',
+	button_width_class: '',
 };

--- a/packages/larva-patterns/modules/button/button.twig
+++ b/packages/larva-patterns/modules/button/button.twig
@@ -1,4 +1,4 @@
-<a class="button larva // {{ button_classes }} {{ button_typography_class }} {{ button_background_color_class }} {{ button_color_class }}"
+<a class="button larva // {{ button_classes }} {{ button_typography_class }} {{ button_background_color_class }} {{ button_color_class }} {{ button_width_class }}"
 	{% if button_url %}
 		href="{{ button_url }}"
 	{% endif %}


### PR DESCRIPTION
<!-- Add a summary of your changes here -->

### Doneness Checklist:

Pre-release # (or n/a):

- [x] Updated root CHANGELOG.md with summary of changes under `Unpublished` section
- [ ] Ran the visual regression tests manually (see [the README](https://github.com/penske-media-corp/pmc-larva#running-visual-regression-tests) for details)
- [x] `npm run prod` in this repo outputs expected changes (excepting the issue with re-ordered partials in larva-css algorithms partials - see [LRVA-1885](https://jira.pmcdev.io/browse/LRVA-1885))
- [ ] If changes to build scripts or the Node.js server, tested changes in pmc-spark [via a pre-release](https://confluence.pmcdev.io/x/XhOeAw)
- - If changes to build tools: npm scripts `prod`, `lint`, and `dev` scripts run as expected
- - If changes to Larva server: Static site generates as expected in a theme  (avail. on a URL {brand}.stg.larva.pmcdev.io)