### PR TITLE
Story refactor

### DIFF
--- a/packages/larva-patterns/modules/story-grid/story-grid.prototype.js
+++ b/packages/larva-patterns/modules/story-grid/story-grid.prototype.js
@@ -6,7 +6,8 @@ story_card.c_dek.c_dek_classes = 'lrv-a-font-body-s lrv-a-hidden@mobile-max lrv-
 story_card.c_title.c_title_classes = 'lrv-a-font-primary-xxs lrv-u-display-block lrv-u-margin-b-050';
 story_card.story_grid_secondary_classes = 'lrv-a-span2';
 story_card.story_links_classes += ' lrv-u-margin-t-050';
-story_card.story_nav_classes = 'lrv-a-font-secondary-m';
+story_card.o_author.o_author_classes = 'lrv-a-font-secondary-m';
+story_card.o_author.story_nav_layout_classes = 'lrv-u-flex lrv-u-align-items-center lrv-a-space-children-horizontal lrv-a-space-children--2 lrv-a-hidden@mobile-max lrv-u-margin-t-050';
 
 module.exports = {
 	story_grid_classes: '',

--- a/packages/larva-patterns/modules/story-grid/story-grid.prototype.js
+++ b/packages/larva-patterns/modules/story-grid/story-grid.prototype.js
@@ -1,6 +1,6 @@
 const { __experimentalCloneWithFallback } = require( '@penskemediacorp/larva' );
 
-const story_card = __experimentalCloneWithFallback( 'modules/story/story.vertical' );
+const story_card = __experimentalCloneWithFallback( 'objects/o-card/o-card.story-vertical' );
 
 story_card.c_dek.c_dek_classes = 'lrv-a-font-body-s lrv-a-hidden@mobile-max lrv-u-margin-a-00';
 story_card.c_title.c_title_classes = 'lrv-a-font-primary-xxs lrv-u-display-block lrv-u-margin-b-050';

--- a/packages/larva-patterns/modules/story-grid/story-grid.river.js
+++ b/packages/larva-patterns/modules/story-grid/story-grid.river.js
@@ -1,0 +1,11 @@
+const { __experimentalCloneWithFallback } = require( '@penskemediacorp/larva' );
+const clonedeep = require( 'lodash.clonedeep' );
+
+const story_grid = __experimentalCloneWithFallback( 'modules/story-grid/story-grid.prototype' );
+const story_prototype = __experimentalCloneWithFallback( 'modules/story/story.prototype' );
+
+story_grid.story_grid_story_cards = story_grid.story_grid_story_cards.map( () => clonedeep( story_prototype ) );
+
+story_grid.story_grid_grid_classes = '';
+
+module.exports = story_grid;

--- a/packages/larva-patterns/modules/story-grid/story-grid.river.js
+++ b/packages/larva-patterns/modules/story-grid/story-grid.river.js
@@ -2,7 +2,7 @@ const { __experimentalCloneWithFallback } = require( '@penskemediacorp/larva' );
 const clonedeep = require( 'lodash.clonedeep' );
 
 const story_grid = __experimentalCloneWithFallback( 'modules/story-grid/story-grid.prototype' );
-const story_prototype = __experimentalCloneWithFallback( 'modules/story/story.prototype' );
+const story_prototype = __experimentalCloneWithFallback( 'objects/o-card/o-card.story' );
 
 story_grid.story_grid_story_cards = story_grid.story_grid_story_cards.map( () => clonedeep( story_prototype ) );
 

--- a/packages/larva-patterns/modules/story-grid/story-grid.twig
+++ b/packages/larva-patterns/modules/story-grid/story-grid.twig
@@ -2,7 +2,7 @@
 	<ul class="{{ story_grid_grid_classes }} // lrv-a-unstyle-list lrv-a-space-children-horizontal lrv-a-space-children--050 lrv-u-margin-b-050">
 		{% for item in story_grid_story_cards %}
 			<li>
-				{% include "@larva/modules/story/story.twig" with item %}
+				{% include "@larva/objects/o-card/o-card.twig" with item %}
 			</li>
 		{% endfor %}
 	</ul>

--- a/packages/larva-patterns/modules/story/story.prototype.js
+++ b/packages/larva-patterns/modules/story/story.prototype.js
@@ -1,43 +1,13 @@
 const { __experimentalCloneWithFallback } = require( '@penskemediacorp/larva' );
-const clonedeep = require( 'lodash.clonedeep' );
 
-const c_span = __experimentalCloneWithFallback( 'components/c-span/c-span.tag' );
-const c_title = __experimentalCloneWithFallback( 'components/c-title/c-title.prototype' );
-const c_dek = __experimentalCloneWithFallback( 'components/c-dek/c-dek.prototype' );
-const c_tagline = __experimentalCloneWithFallback( 'components/c-tagline/c-tagline.prototype' );
-const c_timestamp = __experimentalCloneWithFallback( 'components/c-timestamp/c-timestamp.prototype' );
-
-const c_tagline_author = clonedeep( c_tagline );
-const c_lazy_image = clonedeep( require( '../../components/c-lazy-image/c-lazy-image.prototype' ) );
-
-c_title.c_title_text = '‘A Momentous Weekend’: LACMA’s High-Stakes Collectors Committee Event Raises $2.4 M.';
-c_title.c_title_classes = 'lrv-u-font-size-14 lrv-u-font-size-26@tablet lrv-u-font-size-32@desktop lrv-u-font-family-primary lrv-u-display-block lrv-u-font-weight-normal lrv-u-font-weight-bold@desktop lrv-u-line-height-small lrv-u-margin-b-050';
-c_title.c_title_link_classes = 'lrv-a-unstyle-link lrv-u-color-brand-primary:hover';
-
-c_dek.c_dek_text = false;
-c_dek.c_dek_markup = 'Lorem ipsum <i>dolor</i> sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation.';
-
-c_tagline_author.c_tagline_classes = 'lrv-u-margin-l-050';
-c_tagline_author.c_tagline_markup = "<a href='#'>Staff Writer</a>";
-c_tagline_author.c_tagline_text = false;
-
-c_lazy_image.c_lazy_image_crop_class = 'lrv-a-crop-3x2';
+const o_card = __experimentalCloneWithFallback( 'objects/o-card/o-card.story' );
 
 module.exports = {
 	story_classes: '',
-	story_nav_classes: 'lrv-u-font-size-12 lrv-u-font-family-primary lrv-u-text-transform-uppercase lrv-u-font-weight-bold lrv-u-color-black ',
+	story_nav_classes: 'lrv-u-font-size-12 lrv-u-font-family-primary lrv-u-text-transform-uppercase lrv-u-font-weight-bold lrv-u-color-black',
 	story_nav_layout_classes: 'lrv-u-flex lrv-u-align-items-center lrv-a-space-children-horizontal lrv-a-space-children--2 lrv-a-hidden@mobile-max lrv-u-margin-t-050',
 	story_grid_classes: 'lrv-a-grid lrv-a-cols3',
-	story_grid_primary_classes: 'lrv-u-margin-r-2@desktop-xl lrv-u-margin-r-00 lrv-u-margin-r-1@desktop',
-	story_grid_secondary_classes: 'lrv-a-span2',
+	story_grid_secondary_classes: 'lrv-a-glue-parent u-padding-t-1@mobile-max lrv-u-flex lrv-u-flex-direction-column lrv-u-height-100p lrv-u-justify-content-start lrv-u-margin-r-2@desktop-xl lrv-u-margin-r-00 lrv-u-margin-r-1@desktop lrv-a-span2',
 	story_links_classes: '',
-	c_span,
-	c_link: false,
-	c_link_bottom: false,
-	c_link_bottom_wrapper_classes: '',
-	c_title: c_title,
-	c_dek: c_dek,
-	c_lazy_image: c_lazy_image,
-	c_tagline_author,
-	c_timestamp,
+	o_card
 };

--- a/packages/larva-patterns/modules/story/story.prototype.js
+++ b/packages/larva-patterns/modules/story/story.prototype.js
@@ -4,11 +4,13 @@ const o_card = __experimentalCloneWithFallback( 'objects/o-card/o-card.story' );
 
 module.exports = {
 	story_classes: '',
-	story_nav_classes: 'lrv-u-font-size-12 lrv-u-font-family-primary lrv-u-text-transform-uppercase lrv-u-font-weight-bold lrv-u-color-black',
-	story_nav_layout_classes: 'lrv-u-flex lrv-u-align-items-center lrv-a-space-children-horizontal lrv-a-space-children--2 lrv-a-hidden@mobile-max lrv-u-margin-t-050',
-	story_grid_classes: 'lrv-a-grid lrv-a-cols3',
-	story_grid_primary_classes: 'lrv-u-margin-r-2@desktop-xl lrv-u-margin-r-00 lrv-u-margin-r-1@desktop lrv-a-glue-parent lrv-u-flex lrv-u-flex-direction-column lrv-u-height-100p lrv-u-justify-content-start',
-	story_grid_secondary_classes: 'lrv-a-glue-parent u-padding-t-1@mobile-max lrv-u-flex lrv-u-flex-direction-column lrv-u-justify-content-start lrv-u-margin-r-2@desktop-xl lrv-u-margin-r-00 lrv-u-margin-r-1@desktop lrv-a-span2 lrv-u-margin-r-2@desktop-xl lrv-u-margin-r-00 lrv-u-margin-r-1@desktop',
 	story_links_classes: '',
-	o_card
+	o_card: {
+		... o_card,
+		story_nav_classes: 'lrv-u-font-size-12 lrv-u-font-family-primary lrv-u-text-transform-uppercase lrv-u-font-weight-bold lrv-u-color-black',
+		story_nav_layout_classes: 'lrv-u-flex lrv-u-align-items-center lrv-a-space-children-horizontal lrv-a-space-children--2 lrv-a-hidden@mobile-max lrv-u-margin-t-050',
+		story_grid_classes: 'lrv-a-grid lrv-a-cols3',
+		story_grid_primary_classes: 'lrv-u-margin-r-2@desktop-xl lrv-u-margin-r-00 lrv-u-margin-r-1@desktop lrv-a-glue-parent lrv-u-flex lrv-u-flex-direction-column lrv-u-height-100p lrv-u-justify-content-start',
+		story_grid_secondary_classes: 'lrv-a-glue-parent u-padding-t-1@mobile-max lrv-u-flex lrv-u-flex-direction-column lrv-u-justify-content-start lrv-u-margin-r-2@desktop-xl lrv-u-margin-r-00 lrv-u-margin-r-1@desktop lrv-a-span2 lrv-u-margin-r-2@desktop-xl lrv-u-margin-r-00 lrv-u-margin-r-1@desktop',
+	}
 };

--- a/packages/larva-patterns/modules/story/story.prototype.js
+++ b/packages/larva-patterns/modules/story/story.prototype.js
@@ -7,7 +7,8 @@ module.exports = {
 	story_nav_classes: 'lrv-u-font-size-12 lrv-u-font-family-primary lrv-u-text-transform-uppercase lrv-u-font-weight-bold lrv-u-color-black',
 	story_nav_layout_classes: 'lrv-u-flex lrv-u-align-items-center lrv-a-space-children-horizontal lrv-a-space-children--2 lrv-a-hidden@mobile-max lrv-u-margin-t-050',
 	story_grid_classes: 'lrv-a-grid lrv-a-cols3',
-	story_grid_secondary_classes: 'lrv-a-glue-parent u-padding-t-1@mobile-max lrv-u-flex lrv-u-flex-direction-column lrv-u-height-100p lrv-u-justify-content-start lrv-u-margin-r-2@desktop-xl lrv-u-margin-r-00 lrv-u-margin-r-1@desktop lrv-a-span2',
+	story_grid_primary_classes: 'lrv-u-margin-r-2@desktop-xl lrv-u-margin-r-00 lrv-u-margin-r-1@desktop lrv-a-glue-parent lrv-u-flex lrv-u-flex-direction-column lrv-u-height-100p lrv-u-justify-content-start',
+	story_grid_secondary_classes: 'lrv-a-glue-parent u-padding-t-1@mobile-max lrv-u-flex lrv-u-flex-direction-column lrv-u-justify-content-start lrv-u-margin-r-2@desktop-xl lrv-u-margin-r-00 lrv-u-margin-r-1@desktop lrv-a-span2 lrv-u-margin-r-2@desktop-xl lrv-u-margin-r-00 lrv-u-margin-r-1@desktop',
 	story_links_classes: '',
 	o_card
 };

--- a/packages/larva-patterns/modules/story/story.right-borders.js
+++ b/packages/larva-patterns/modules/story/story.right-borders.js
@@ -2,8 +2,8 @@ const clonedeep = require( 'lodash.clonedeep' );
 
 const story_right_borders = clonedeep( require( './story.right' ) );
 
-story_right_borders.story_grid_classes += ' lrv-u-border-a-1';
+story_right_borders.o_card.story_grid_classes += ' lrv-u-border-a-1';
 
-story_right_borders.story_grid_secondary_classes += ' lrv-u-padding-l-2@desktop-xl lrv-u-padding-l-00 lrv-u-padding-l-1@desktop';
+story_right_borders.o_card.story_grid_secondary_classes += ' lrv-u-padding-l-2@desktop-xl lrv-u-padding-l-00 lrv-u-padding-l-1@desktop';
 
 module.exports = story_right_borders;

--- a/packages/larva-patterns/modules/story/story.right.js
+++ b/packages/larva-patterns/modules/story/story.right.js
@@ -2,13 +2,13 @@ const { __experimentalCloneWithFallback } = require( '@penskemediacorp/larva' );
 
 const story_right = __experimentalCloneWithFallback( 'modules/story/story.prototype' );
 
-story_right.story_grid_primary_classes = 'lrv-u-margin-l-2@desktop-xl lrv-u-margin-l-00 lrv-u-margin-l-1@desktop';
+story_right.o_card.story_grid_primary_classes = 'lrv-u-margin-l-2@desktop-xl lrv-u-margin-l-00 lrv-u-margin-l-1@desktop';
 
-story_right.story_grid_primary_classes += ' lrv-u-order-100';
-story_right.story_grid_secondary_classes += ' lrv-u-order-n1 lrv-u-text-align-right';
+story_right.o_card.story_grid_primary_classes += ' lrv-u-order-100';
+story_right.o_card.story_grid_secondary_classes += ' lrv-u-order-n1 lrv-u-text-align-right';
 
-story_right.story_nav_classes += ' lrv-u-justify-content-end';
-story_right.story_links_classes += ' lrv-u-justify-content-end';
-story_right.c_link_bottom_wrapper_classes += ' lrv-u-justify-content-end';
+story_right.o_card.story_nav_classes += ' lrv-u-justify-content-end';
+story_right.o_card.story_links_classes += ' lrv-u-justify-content-end';
+story_right.o_card.c_link_bottom_wrapper_classes += ' lrv-u-justify-content-end';
 
 module.exports = story_right;

--- a/packages/larva-patterns/modules/story/story.story-arc.js
+++ b/packages/larva-patterns/modules/story/story.story-arc.js
@@ -4,6 +4,7 @@ const story_story_arc = clonedeep( require( './story.prototype' ) );
 
 const story_arc_stories = clonedeep( require( '../story-arc-stories/story-arc-stories.prototype' ) );
 
-story_story_arc.story_arc_stories = story_arc_stories;
-
-module.exports = story_story_arc;
+module.exports = {
+	... story_story_arc,
+	story_arc_stories
+};

--- a/packages/larva-patterns/modules/story/story.twig
+++ b/packages/larva-patterns/modules/story/story.twig
@@ -1,6 +1,5 @@
 <div class="story lrv-u-padding-tb-1 lrv-u-padding-tb-2@desktop // {{ story_classes }}">
-	<div class="{{ story_grid_classes }}">
-
+{#
 		<div class="{{ story_grid_primary_classes }} // lrv-a-glue-parent u-padding-t-1@mobile-max lrv-u-flex lrv-u-flex-direction-column lrv-u-height-100p lrv-u-justify-content-start">
 			<div class="lrv-a-glue-parent">
 				{% if c_lazy_image %}
@@ -67,7 +66,8 @@
 
 		</div>
 
-	</div>
+	</div> #}
+	{% include "@larva/objects/o-card/o-card.twig" with o_card %}
 
 	{% if story_arc_stories %}
 		<div class="lrv-u-margin-t-1 lrv-u-margin-t-2@desktop">

--- a/packages/larva-patterns/modules/story/story.vertical.js
+++ b/packages/larva-patterns/modules/story/story.vertical.js
@@ -1,11 +1,5 @@
 const { __experimentalCloneWithFallback } = require( '@penskemediacorp/larva' );
 
-const story_vertical = __experimentalCloneWithFallback( 'modules/story/story.prototype' );
-
-story_vertical.story_grid_classes = '';
-
-story_vertical.story_grid_primary_classes = 'lrv-u-margin-r-00';
-
-story_vertical.story_grid_secondary_classes += ' lrv-u-padding-lr-1 lrv-u-padding-lr-2@desktop-xl lrv-u-padding-tb-075 lrv-u-padding-tb-150@desktop-xl';
+const story_vertical = __experimentalCloneWithFallback( 'objects/o-card/o-card.story-vertical' );
 
 module.exports = story_vertical;

--- a/packages/larva-patterns/objects/o-author/o-author.twig
+++ b/packages/larva-patterns/objects/o-author/o-author.twig
@@ -1,9 +1,10 @@
-<div class="o-author // {{ o_author_classes }}">
-
-	<span class="{{ o_author_by_classes }}">{{ o_author_text }}</span>
+<div class="o-author // {{ o_author_classes }} {{ story_nav_classes }} {{ story_nav_layout_classes }}">
 
 	{% if c_span %}
-		{% include "@larva/components/c-span/c-span.twig" with c_span %}
+		<div>
+			<span class="{{ o_author_by_classes }}">{{ o_author_text }}</span>
+			{% include "@larva/components/c-span/c-span.twig" with c_span %}
+		</div>
 	{% endif %}
 
 	{% if c_timestamp %}

--- a/packages/larva-patterns/objects/o-card/o-card.story-vertical.js
+++ b/packages/larva-patterns/objects/o-card/o-card.story-vertical.js
@@ -1,0 +1,11 @@
+const { __experimentalCloneWithFallback } = require( '@penskemediacorp/larva' );
+
+const story_vertical = __experimentalCloneWithFallback( 'objects/o-card/o-card.story' );
+
+story_vertical.story_grid_classes = '';
+
+story_vertical.story_grid_primary_classes = 'lrv-u-margin-r-00';
+
+story_vertical.story_grid_secondary_classes += ' lrv-u-padding-lr-1 lrv-u-padding-lr-2@desktop-xl lrv-u-padding-tb-075 lrv-u-padding-tb-150@desktop-xl';
+
+module.exports = story_vertical;

--- a/packages/larva-patterns/objects/o-card/o-card.story.js
+++ b/packages/larva-patterns/objects/o-card/o-card.story.js
@@ -22,7 +22,6 @@ o_card.c_tagline.c_tagline_text = false;
 o_card.c_lazy_image.c_lazy_image_crop_class = 'lrv-a-crop-3x2';
 
 o_card.o_card_classes = 'lrv-u-align-items-center';
-o_card.o_card_image_wrap_classes = 'lrv-a-glue-parent u-padding-t-1@mobile-max lrv-u-flex lrv-u-flex-direction-column lrv-u-height-100p lrv-u-justify-content-start lrv-u-margin-r-2@desktop-xl lrv-u-margin-r-00 lrv-u-margin-r-1@desktop';
 
 o_author.c_span.c_span_url = '#';
 

--- a/packages/larva-patterns/objects/o-card/o-card.story.js
+++ b/packages/larva-patterns/objects/o-card/o-card.story.js
@@ -1,0 +1,32 @@
+const { __experimentalCloneWithFallback } = require( '@penskemediacorp/larva' );
+
+const o_card = __experimentalCloneWithFallback( 'objects/o-card/o-card.prototype' );
+const c_dek = __experimentalCloneWithFallback( 'components/c-dek/c-dek.prototype' );
+const o_author = __experimentalCloneWithFallback( 'objects/o-author/o-author.prototype' );
+
+o_card.c_title.c_title_text = '‘A Momentous Weekend’: LACMA’s High-Stakes Collectors Committee Event Raises $2.4 M.';
+o_card.c_title.c_title_classes = 'lrv-u-font-size-14 lrv-u-font-size-26@tablet lrv-u-font-size-32@desktop lrv-u-font-family-primary lrv-u-display-block lrv-u-font-weight-normal lrv-u-font-weight-bold@desktop lrv-u-line-height-small lrv-u-margin-b-050';
+o_card.c_title.c_title_link_classes = 'lrv-a-unstyle-link lrv-u-color-brand-primary:hover';
+
+o_card.c_span.c_span_classes = 'lrv-u-margin-b-050 lrv-u-display-inline-block';
+
+o_card.c_dek = c_dek;
+o_card.c_timestamp = false;
+o_card.c_dek.c_dek_text = false;
+o_card.c_dek.c_dek_markup = 'Lorem ipsum <i>dolor</i> sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation.';
+
+o_card.c_tagline.c_tagline_classes = 'lrv-u-margin-l-050';
+o_card.c_tagline.c_tagline_markup = "<a href='#'>Staff Writer</a>";
+o_card.c_tagline.c_tagline_text = false;
+
+o_card.c_lazy_image.c_lazy_image_crop_class = 'lrv-a-crop-3x2';
+
+o_card.o_card_classes = 'lrv-u-align-items-center';
+o_card.o_card_image_wrap_classes = 'lrv-a-glue-parent u-padding-t-1@mobile-max lrv-u-flex lrv-u-flex-direction-column lrv-u-height-100p lrv-u-justify-content-start lrv-u-margin-r-2@desktop-xl lrv-u-margin-r-00 lrv-u-margin-r-1@desktop';
+
+o_author.c_span.c_span_url = '#';
+
+module.exports = {
+	... o_card,
+	o_author
+};

--- a/packages/larva-patterns/objects/o-card/o-card.twig
+++ b/packages/larva-patterns/objects/o-card/o-card.twig
@@ -1,7 +1,7 @@
 {% if o_card_tag_text %}
 <{{ o_card_tag_text }} class="o-card {{ modifier_class }} {{ o_card_classes }}">
 {% else %}
-<article class="o-card {{ modifier_class }} {{ o_card_classes }}">
+<article class="o-card {{ modifier_class }} {{ story_grid_classes }} {{ o_card_classes }}">
 {% endif %}
 
 	{% if o_card_link_url %}
@@ -9,7 +9,7 @@
 	{% endif %}
 
 	{% if o_card_image_wrap_classes %}
-	<div class="o-card__image-wrap {{ o_card_image_wrap_classes }}">
+	<div class="o-card__image-wrap {{ o_card_image_wrap_classes }} {{ story_grid_primary_classes }}">
 		{% endif %}
 
 		{% if c_lazy_image %}
@@ -24,7 +24,7 @@
 	</div>
 	{% endif %}
 
-	<div class="o-card__content {{ o_card_content_classes }}">
+	<div class="o-card__content {{ o_card_content_classes }} {{ story_grid_secondary_classes }}">
 		{% if o_span_group %}
 			{% include "@larva/objects/o-span-group/o-span-group.twig" with o_span_group %}
 		{% endif %}
@@ -52,6 +52,15 @@
 		{% if o_author %}
 			{% include "@larva/objects/o-author/o-author.twig" with o_author %}
 		{% endif %}
+
+		{% if c_link_bottom %}
+			<div class="lrv-u-flex lrv-u-order-100 lrv-u-margin-t-050 // {{ c_link_bottom_wrapper_classes }}">
+				{% if c_link_bottom %}
+					{% include "@larva/components/c-link/c-link.twig" with c_link_bottom %}
+				{% endif %}
+			</div>
+		{% endif %}
+
 	</div>
 
 	{% if o_card_link_url %}

--- a/packages/larva-patterns/objects/o-card/o-card.twig
+++ b/packages/larva-patterns/objects/o-card/o-card.twig
@@ -8,10 +8,7 @@
 		<a tabindex="0" href="{{ o_card_link_url }}" class="{{ o_card_link_classes }}">
 	{% endif %}
 
-	{% if o_card_image_wrap_classes %}
 	<div class="o-card__image-wrap {{ o_card_image_wrap_classes }} {{ story_grid_primary_classes }}">
-		{% endif %}
-
 		{% if c_lazy_image %}
 			{% include "@larva/components/c-lazy-image/c-lazy-image.twig" with c_lazy_image %}
 		{% endif %}
@@ -20,9 +17,7 @@
 			{% include "@larva/objects/o-indicator/o-indicator.twig" with o_indicator %}
 		{% endif %}
 
-		{% if o_card_image_wrap_classes %}
 	</div>
-	{% endif %}
 
 	<div class="o-card__content {{ o_card_content_classes }} {{ story_grid_secondary_classes }}">
 		{% if o_span_group %}


### PR DESCRIPTION
The PR demonstrates the need for an API for customizing CSS classes (or, um, we could write CSS? and use custom properties?)

### Doneness Checklist:

Pre-release # (or n/a):

- [ ] Updated root CHANGELOG.md with summary of changes under `Unpublished` section
- [ ] Ran the visual regression tests manually (see [the README](https://github.com/penske-media-corp/pmc-larva#running-visual-regression-tests) for details)
- [ ] `npm run prod` in this repo outputs expected changes (excepting the issue with re-ordered partials in larva-css algorithms partials - see [LRVA-1885](https://jira.pmcdev.io/browse/LRVA-1885))
- [ ] If changes to build scripts or the Node.js server, tested changes in pmc-spark [via a pre-release](https://confluence.pmcdev.io/x/XhOeAw)
- - If changes to build tools: npm scripts `prod`, `lint`, and `dev` scripts run as expected
- - If changes to Larva server: Static site generates as expected in a theme  (avail. on a URL {brand}.stg.larva.pmcdev.io)