### PR TITLE
add fonts to artnews.json and run npm build-tokens

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3656,14 +3656,14 @@
       "requires": {
         "@babel/core": "^7.10.5",
         "@babel/preset-env": "^7.10.4",
-        "@penskemediacorp/backstopjs-config": "^0.5.0",
+        "@penskemediacorp/backstopjs-config": "^0.5.4",
         "@penskemediacorp/eslint-config": "^0.5.0",
-        "@penskemediacorp/larva-css": "^0.5.3",
+        "@penskemediacorp/larva-css": "^0.5.5",
         "@penskemediacorp/larva-js": "^0.5.0",
-        "@penskemediacorp/larva-patterns": "^0.5.3",
-        "@penskemediacorp/larva-scss": "^0.5.0",
+        "@penskemediacorp/larva-patterns": "^0.5.5",
+        "@penskemediacorp/larva-scss": "^0.5.4",
         "@penskemediacorp/larva-svg": "^0.5.0",
-        "@penskemediacorp/larva-tokens": "^0.5.3",
+        "@penskemediacorp/larva-tokens": "^0.5.4",
         "@penskemediacorp/stylelint-config": "^0.5.0",
         "@penskemediacorp/twig-to-php-parser": "^0.5.0",
         "axios": "^0.21.1",
@@ -3767,7 +3767,7 @@
     "@penskemediacorp/larva-patterns": {
       "version": "file:packages/larva-patterns",
       "requires": {
-        "@penskemediacorp/larva-css": "^0.5.3",
+        "@penskemediacorp/larva-css": "^0.5.5",
         "@penskemediacorp/larva-js": "^0.5.0",
         "@penskemediacorp/larva-svg": "^0.5.0",
         "lodash.clonedeep": "^4.5.0"

--- a/packages/larva-tokens/src/brands/artnews.json
+++ b/packages/larva-tokens/src/brands/artnews.json
@@ -61,6 +61,150 @@
 			"value": "{!HELVETICA_NEUE}",
 			"type": "font-family",
 			"category": "font-family"
+		},
+		"PRIMARY_XL_FONT_SIZE_DESKTOP": {
+			"selector": "lrv-a-font",
+			"status": "alpha",
+			"category": "font-size",
+			"type": "number",
+			"value": "58px",
+			"originalValue": "58px",
+			"name": "PRIMARY_XL_FONT_SIZE_DESKTOP"
+		},
+		"PRIMARY_XL_FONT_SIZE_MOBILE": {
+			"selector": "lrv-a-font",
+			"status": "alpha",
+			"category": "font-size",
+			"type": "number",
+			"value": "48px",
+			"originalValue": "37px",
+			"name": "PRIMARY_XL_FONT_SIZE_MOBILE"
+		},
+		"PRIMARY_L_FONT_SIZE_DESKTOP": {
+			"selector": "lrv-a-font",
+			"status": "alpha",
+			"category": "font-size",
+			"type": "number",
+			"value": "44px",
+			"originalValue": "45px",
+			"name": "PRIMARY_L_FONT_SIZE_DESKTOP"
+		},
+		"PRIMARY_L_FONT_SIZE_MOBILE": {
+			"selector": "lrv-a-font",
+			"status": "alpha",
+			"category": "font-size",
+			"type": "number",
+			"value": "40px",
+			"originalValue": "34px",
+			"name": "PRIMARY_L_FONT_SIZE_MOBILE"
+		},
+		"PRIMARY_M_FONT_SIZE_DESKTOP": {
+			"selector": "lrv-a-font",
+			"status": "alpha",
+			"category": "font-size",
+			"type": "number",
+			"value": "40px",
+			"originalValue": "36px",
+			"name": "PRIMARY_M_FONT_SIZE_DESKTOP"
+		},
+		"PRIMARY_M_FONT_SIZE_MOBILE": {
+			"selector": "lrv-a-font",
+			"status": "alpha",
+			"category": "font-size",
+			"type": "number",
+			"value": "37px",
+			"originalValue": "32px",
+			"name": "PRIMARY_M_FONT_SIZE_MOBILE"
+		},
+		"PRIMARY_S_FONT_SIZE_DESKTOP": {
+			"selector": "lrv-a-font",
+			"status": "alpha",
+			"category": "font-size",
+			"type": "number",
+			"value": "32px",
+			"originalValue": "36px",
+			"name": "PRIMARY_S_FONT_SIZE_DESKTOP"
+		},
+		"PRIMARY_S_FONT_SIZE_MOBILE": {
+			"selector": "lrv-a-font",
+			"status": "alpha",
+			"category": "font-size",
+			"type": "number",
+			"value": "28px",
+			"originalValue": "23px",
+			"name": "PRIMARY_S_FONT_SIZE_MOBILE"
+		},
+		"PRIMARY_XS_FONT_SIZE_DESKTOP": {
+			"selector": "lrv-a-font",
+			"status": "alpha",
+			"category": "font-size",
+			"type": "number",
+			"value": "48px",
+			"originalValue": "36px",
+			"name": "PRIMARY_XS_FONT_SIZE_DESKTOP"
+		},
+		"PRIMARY_XS_FONT_SIZE_MOBILE": {
+			"selector": "lrv-a-font",
+			"status": "alpha",
+			"category": "font-size",
+			"type": "number",
+			"value": "34px",
+			"originalValue": "23px",
+			"name": "PRIMARY_XS_FONT_SIZE_MOBILE"
+		},
+		"PRIMARY_XXS_FONT_SIZE_DESKTOP": {
+			"selector": "lrv-a-font",
+			"status": "alpha",
+			"category": "font-size",
+			"type": "number",
+			"value": "48px",
+			"originalValue": "36px",
+			"name": "PRIMARY_XXS_FONT_SIZE_DESKTOP"
+		},
+		"PRIMARY_XXS_FONT_SIZE_MOBILE": {
+			"selector": "lrv-a-font",
+			"status": "alpha",
+			"category": "font-size",
+			"type": "number",
+			"value": "35px",
+			"originalValue": "23px",
+			"name": "PRIMARY_XXS_FONT_SIZE_MOBILE"
+		},
+		"SECONDARY_L_FONT_SIZE_DESKTOP": {
+			"selector": "lrv-a-font",
+			"status": "alpha",
+			"category": "font-size",
+			"type": "number",
+			"value": "56px",
+			"originalValue": "14px",
+			"name": "SECONDARY_L_FONT_SIZE_DESKTOP"
+		},
+		"SECONDARY_L_FONT_SIZE_MOBILE": {
+			"selector": "lrv-a-font",
+			"status": "alpha",
+			"category": "font-size",
+			"type": "number",
+			"value": "40px",
+			"originalValue": "11px",
+			"name": "SECONDARY_L_FONT_SIZE_MOBILE"
+		},
+		"SECONDARY_M_FONT_SIZE_DESKTOP": {
+			"selector": "lrv-a-font",
+			"status": "alpha",
+			"category": "font-size",
+			"type": "number",
+			"value": "26px",
+			"originalValue": "14px",
+			"name": "SECONDARY_M_FONT_SIZE_DESKTOP"
+		},
+		"SECONDARY_M_FONT_SIZE_MOBILE": {
+			"selector": "lrv-a-font",
+			"status": "alpha",
+			"category": "font-size",
+			"type": "number",
+			"value": "21px",
+			"originalValue": "11px",
+			"name": "SECONDARY_M_FONT_SIZE_MOBILE"
 		}
 	}
 }


### PR DESCRIPTION
<!-- Add a summary of your changes here -->

### Make sure you complete these items:

- [ ] Updated root CHANGELOG.md with summary of changes under `Unpublished` section
- [ ] `npm run prod` in this repo outputs expected changes (excepting the issue with re-ordered partials in larva-css algorithms partials - see [LRVA-1885](https://jira.pmcdev.io/browse/LRVA-1885))
- [ ] If adding a new pattern, in the PR comment, included a screenshot and link to the static Vercel deployment
- [ ] If changes to build scripts or the Node.js server, tested changes in pmc-spark [via a pre-release](https://confluence.pmcdev.io/x/XhOeAw)
- - If changes to build tools: npm scripts `prod`, `lint`, and `dev` scripts run as expected
- - If changes to Larva server: Static site generates as expected in a theme  (avail. on a URL {brand}.stg.larva.pmcdev.io)