### PR TITLE
Update the email field component a11y by using the input id for the l…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unpublished
+* larva-patterns - Update `c-email-field` component and 'newsletter' module to improve label and input accessibility.
+
 ## 0.5.6 - 03-29-2022
 * larva-tokens - Add desktop_xl token values in typography.json
 * larva-tokens - Add desktop_xl breakpoint in font-data.js

--- a/packages/larva-patterns/components/c-email-field/c-email-field.prototype.js
+++ b/packages/larva-patterns/components/c-email-field/c-email-field.prototype.js
@@ -1,7 +1,6 @@
 module.exports = {
 	c_email_field_classes: '',
 	c_email_field_label_classes: '',
-	c_email_field_label_for_attr: '',
 	c_email_field_label_text: 'Your Email',
 	c_email_field_input_id_attr: '',
 	c_email_field_input_name_attr: '',

--- a/packages/larva-patterns/components/c-email-field/c-email-field.twig
+++ b/packages/larva-patterns/components/c-email-field/c-email-field.twig
@@ -1,4 +1,4 @@
 <div class="c-email-field {{ modifier_class }} {{ c_email_field_classes }}">
-	<label class="c-email-field__label {{ c_email_field_label_classes }}" for="{{ c_email_field_label_for_attr }}">{{ c_email_field_label_text }}</label>
+	<label class="c-email-field__label {{ c_email_field_label_classes }}" for="{{ c_email_field_input_id_attr }}">{{ c_email_field_label_text }}</label>
 	<input class="c-email-field__input {{ c_email_field_input_classes }}" name="{{ c_email_field_input_name_attr }}" id="{{ c_email_field_input_id_attr }}" required type="email" placeholder="{{ c_email_field_input_placeholder_attr }}" pattern="[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,4}$" />
 </div>

--- a/packages/larva-patterns/modules/newsletter/newsletter.prototype.js
+++ b/packages/larva-patterns/modules/newsletter/newsletter.prototype.js
@@ -21,7 +21,7 @@ c_logo.c_logo_classes = 'lrv-a-unstyle-link lrv-u-display-contents lrv-u-width-1
 
 o_email_capture_form.c_email_field.c_email_field_input_placeholder_attr = 'Email';
 o_email_capture_form.c_email_field.c_email_field_input_classes += ' lrv-u-border-a-0 lrv-u-font-size-14 lrv-u-width-100p lrv-u-margin-b-1 lrv-u-padding-lr-1 lrv-u-padding-tb-050 lrv-u-border-radius-5';
-o_email_capture_form.c_email_field.c_email_field_label_for_attr = 'EmailAddress';
+o_email_capture_form.c_email_field.c_email_field_input_id_attr = 'EmailAddress';
 o_email_capture_form.c_email_field.c_email_field_input_name_attr = 'EmailAddress';
 o_email_capture_form.c_button.c_button_text = 'Subscribe Today';
 o_email_capture_form.c_button.c_button_classes += ' lrv-u-background-color-black lrv-u-color-white lrv-u-border-radius-5 lrv-u-width-100p lrv-u-text-align-center lrv-u-padding-a-050 lrv-u-font-weight-bold';


### PR DESCRIPTION
…abel for

### For Reviewers
This PR, when applied, improves accessibility for the `c-email-field` component and `newsletter` module.

#### Updated Pattern
[Styleguide](https://pmc-larva-git-feature-pmcp-3730-penske-media-corp.vercel.app/larva/components/c-email-field/)
<img width="1679" alt="Screen Shot 2022-03-31 at 2 14 49 PM" src="https://user-images.githubusercontent.com/665107/161132141-01e52a1e-c660-4c9d-8e83-ba39fc59b783.png">


### Make sure you complete these items:

- [x] Updated root CHANGELOG.md with summary of changes under `Unpublished` section
- [x] `npm run prod` in this repo outputs expected changes (excepting the issue with re-ordered partials in larva-css algorithms partials - see [LRVA-1885](https://jira.pmcdev.io/browse/LRVA-1885))
- [x] If adding a new pattern, in the PR comment, included a screenshot and link to the static Vercel deployment
- [x] If changes to build scripts or the Node.js server, tested changes in pmc-spark [via a pre-release](https://confluence.pmcdev.io/x/XhOeAw)
- - If changes to build tools: npm scripts `prod`, `lint`, and `dev` scripts run as expected
- - If changes to Larva server: Static site generates as expected in a theme  (avail. on a URL {brand}.stg.larva.pmcdev.io)