### PR TITLE
Prepare for 0.5.7 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unpublished
+
+## 0.5.7 - 04-05-2022
 * larva-patterns - Add `article-callout` module.
 * larva-patterns - Update `c-email-field` component and 'newsletter' module to improve label and input accessibility.
 * all - Add github action on workflow-dispatch to update the visual regression tests in the same environment in which they are run

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,4 +1,3 @@
-
 {
   "name": "@penskemediacorp/pmc-larva",
   "version": "1.0.0",
@@ -3703,15 +3702,6 @@
         "webpack-cli": "^3.3.12"
       },
       "dependencies": {
-        "@penskemediacorp/twig-to-php-parser": {
-          "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/@penskemediacorp/twig-to-php-parser/-/twig-to-php-parser-0.5.0.tgz",
-          "integrity": "sha512-shyJOCNJR4VOFl7p0HMt8tr3PZZNO6vNgzzYHj1r1F4qEKzQIB10ZiRykNlR2Y1P2RSWfoFA5CrtqhL/cYAFEQ==",
-          "requires": {
-            "chalk": "^4.1.0",
-            "exec-php": "0.0.5"
-          }
-        },
         "marked": {
           "version": "4.0.12",
           "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.12.tgz",
@@ -3878,6 +3868,15 @@
     },
     "@penskemediacorp/stylelint-config": {
       "version": "file:packages/stylelint-config"
+    },
+    "@penskemediacorp/twig-to-php-parser": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/@penskemediacorp/twig-to-php-parser/-/twig-to-php-parser-0.5.6.tgz",
+      "integrity": "sha512-t4kIxGaJyltlAarTe4zC9/dbq/ZBKtO942v4WSHBfSAQXMfX56EhyzlA5+GZTeqj+mx29Y2BxaGT6U/CTb1Faw==",
+      "requires": {
+        "chalk": "^4.1.0",
+        "exec-php": "0.0.5"
+      }
     },
     "@sindresorhus/is": {
       "version": "0.14.0",

--- a/packages/eslint-config/package-lock.json
+++ b/packages/eslint-config/package-lock.json
@@ -252,13 +252,6 @@
 				"globals": "^12.0.0",
 				"prettier": "npm:wp-prettier@2.2.1-beta-1",
 				"requireindex": "^1.2.0"
-			},
-			"dependencies": {
-				"prettier": {
-					"version": "npm:wp-prettier@2.2.1-beta-1",
-					"resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.2.1-beta-1.tgz",
-					"integrity": "sha512-+JHkqs9LC/JPp51yy1hzs3lQ7qeuWCwOcSzpQNeeY/G7oSpnF61vxt7hRh87zNRTr6ob2ndy0W8rVzhgrcA+Gw=="
-				}
 			}
 		},
 		"@wordpress/prettier-config": {
@@ -1269,6 +1262,11 @@
 			"requires": {
 				"find-up": "^2.1.0"
 			}
+		},
+		"prettier": {
+			"version": "npm:wp-prettier@2.2.1-beta-1",
+			"resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.2.1-beta-1.tgz",
+			"integrity": "sha512-+JHkqs9LC/JPp51yy1hzs3lQ7qeuWCwOcSzpQNeeY/G7oSpnF61vxt7hRh87zNRTr6ob2ndy0W8rVzhgrcA+Gw=="
 		},
 		"prettier-linter-helpers": {
 			"version": "1.0.0",

--- a/packages/larva-css/package-lock.json
+++ b/packages/larva-css/package-lock.json
@@ -37,9 +37,9 @@
 			"dev": true
 		},
 		"@penskemediacorp/larva-tokens": {
-			"version": "0.5.4",
-			"resolved": "https://registry.npmjs.org/@penskemediacorp/larva-tokens/-/larva-tokens-0.5.4.tgz",
-			"integrity": "sha512-AHlYbLNgQ2HQ4VCcgjlAdD5H5PuTgR0z2GUW+sd6LjyBW5YvhyXsNhCWinu8SvRwOo9gtw7Ub2iHzZpNEMZvLw==",
+			"version": "0.5.6",
+			"resolved": "https://registry.npmjs.org/@penskemediacorp/larva-tokens/-/larva-tokens-0.5.6.tgz",
+			"integrity": "sha512-5P3IT4ZdC378SngpOffUktIK63FAV1OtGIpUv6hwEXhcOqOzyLO8dJqDkEf8F2NsQlp4/Q35SYyc+KIOLZQ2Cg==",
 			"dev": true,
 			"requires": {
 				"gulp": "^4.0.2",

--- a/packages/larva-patterns/package-lock.json
+++ b/packages/larva-patterns/package-lock.json
@@ -5,14 +5,14 @@
 	"requires": true,
 	"dependencies": {
 		"@penskemediacorp/larva-css": {
-			"version": "0.5.5",
-			"resolved": "https://registry.npmjs.org/@penskemediacorp/larva-css/-/larva-css-0.5.5.tgz",
-			"integrity": "sha512-YbQwaSYFcGJ8FIXoi21w+hEVvZMQwEYTSM7yg1sv/3uF03o2TYm8sTMqQXou0fiDNW0apmU/o+j0KIFrsYIsPA=="
+			"version": "0.5.6",
+			"resolved": "https://registry.npmjs.org/@penskemediacorp/larva-css/-/larva-css-0.5.6.tgz",
+			"integrity": "sha512-77JGGsYRncdkGcUWBUCbjjTavpxFew5gDG+WpmeBYjuqxkvb9NaXsg6oK4pCsfRSO3vX23l3oWlaOkShNEeFmQ=="
 		},
 		"@penskemediacorp/larva-js": {
-			"version": "0.5.0",
-			"resolved": "https://registry.npmjs.org/@penskemediacorp/larva-js/-/larva-js-0.5.0.tgz",
-			"integrity": "sha512-bRitSp1p/0tbGhfEx4k+TyXvYOr2opy1s2kxcU5jiXTtRP7YNjGM+f/aYjgpAbCQj0/YgOLPhviZ8rMcB9KY1A==",
+			"version": "0.5.6",
+			"resolved": "https://registry.npmjs.org/@penskemediacorp/larva-js/-/larva-js-0.5.6.tgz",
+			"integrity": "sha512-gAvJkJsNRtkioINmCN5gzb5pItu2nZc1sV4RklzDXIrrtwXnJ+/oqH7cHsaepCUiijvb8WpujqUXvJV1dG2cvg==",
 			"requires": {
 				"flickity": "^2.2.1",
 				"webpack": "^4.43.0",
@@ -218,9 +218,9 @@
 			"integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ=="
 		},
 		"ansi-regex": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-			"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
+			"integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g=="
 		},
 		"ansi-styles": {
 			"version": "3.2.1",
@@ -1450,9 +1450,9 @@
 			}
 		},
 		"graceful-fs": {
-			"version": "4.2.9",
-			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.9.tgz",
-			"integrity": "sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ=="
+			"version": "4.2.10",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
+			"integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
 		},
 		"has-flag": {
 			"version": "3.0.0",
@@ -1889,17 +1889,17 @@
 			"integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo="
 		},
 		"minimatch": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
 			"requires": {
 				"brace-expansion": "^1.1.7"
 			}
 		},
 		"minimist": {
-			"version": "1.2.5",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-			"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+			"version": "1.2.6",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+			"integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
 		},
 		"mississippi": {
 			"version": "3.0.0",
@@ -1938,11 +1938,11 @@
 			}
 		},
 		"mkdirp": {
-			"version": "0.5.5",
-			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-			"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+			"version": "0.5.6",
+			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+			"integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
 			"requires": {
-				"minimist": "^1.2.5"
+				"minimist": "^1.2.6"
 			}
 		},
 		"move-concurrently": {

--- a/packages/larva/package-lock.json
+++ b/packages/larva/package-lock.json
@@ -1619,6 +1619,11 @@
             "lines-and-columns": "^1.1.6"
           }
         },
+        "prettier": {
+          "version": "npm:wp-prettier@2.2.1-beta-1",
+          "resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.2.1-beta-1.tgz",
+          "integrity": "sha512-+JHkqs9LC/JPp51yy1hzs3lQ7qeuWCwOcSzpQNeeY/G7oSpnF61vxt7hRh87zNRTr6ob2ndy0W8rVzhgrcA+Gw=="
+        },
         "resolve-from": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -10227,11 +10232,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
       "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc="
-    },
-    "prettier": {
-      "version": "npm:wp-prettier@2.2.1-beta-1",
-      "resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.2.1-beta-1.tgz",
-      "integrity": "sha512-+JHkqs9LC/JPp51yy1hzs3lQ7qeuWCwOcSzpQNeeY/G7oSpnF61vxt7hRh87zNRTr6ob2ndy0W8rVzhgrcA+Gw=="
     },
     "prettier-linter-helpers": {
       "version": "1.0.0",


### PR DESCRIPTION
## Summary
This PR, when applied, updates Larva to `0.5.7`.

### Notes for Reviewers

### Make sure you complete these items:
- [x] Updated root CHANGELOG.md with summary of changes under `Unpublished` section
- [x] `npm run prod` in this repo outputs expected changes (excepting the issue with re-ordered partials in larva-css algorithms partials - see [LRVA-1885](https://jira.pmcdev.io/browse/LRVA-1885))
- [o] If adding a new pattern, in the PR comment, included a screenshot and link to the static Vercel deployment
- [o] If changes to build scripts or the Node.js server, tested changes in pmc-spark [via a pre-release](https://confluence.pmcdev.io/x/XhOeAw)
- - If changes to build tools: npm scripts `prod`, `lint`, and `dev` scripts run as expected
- - If changes to Larva server: Static site generates as expected in a theme  (avail. on a URL {brand}.stg.larva.pmcdev.io)