### PR TITLE
Update changelog for `0.5.7` release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unpublished
+
+## 0.5.7 - 04-05-2022
 * larva-patterns - Add `article-callout` module.
 * larva-patterns - Update `c-email-field` component and 'newsletter' module to improve label and input accessibility.
 * all - Add github action on workflow-dispatch to update the visual regression tests in the same environment in which they are run


### PR DESCRIPTION
## Summary
Updates the changelog to reflect the `0.5.7` release.

### Make sure you complete these items:
- [x] Updated root CHANGELOG.md with summary of changes under `Unpublished` section
- [o] `npm run prod` in this repo outputs expected changes (excepting the issue with re-ordered partials in larva-css algorithms partials - see [LRVA-1885](https://jira.pmcdev.io/browse/LRVA-1885))
- [o] If adding a new pattern, in the PR comment, included a screenshot and link to the static Vercel deployment
- [o] If changes to build scripts or the Node.js server, tested changes in pmc-spark [via a pre-release](https://confluence.pmcdev.io/x/XhOeAw)
- - If changes to build tools: npm scripts `prod`, `lint`, and `dev` scripts run as expected
- - If changes to Larva server: Static site generates as expected in a theme  (avail. on a URL {brand}.stg.larva.pmcdev.io)