### PR TITLE
Changing the structure of generated php comments in the twig parser.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unpublished
+* twig-to-php-parser - Modify generated comment in php as a proper fileDoc to adhere to standards.
+
 ## 0.6.0 - 04-13-2022
 * larva-tokens - Added artinamerica tokens for hub support
 * larva-tokens - Updated RS token as per desktop_xl changes.

--- a/packages/twig-to-php-parser/__tests__/fixtures/template-parts-expected/patterns/components/c-button.php
+++ b/packages/twig-to-php-parser/__tests__/fixtures/template-parts-expected/patterns/components/c-button.php
@@ -1,5 +1,10 @@
 <?php
-// This is a generated file. Refer to the relevant Twig file for adjusting this markup.
+/**
+* Generated file.
+*
+* Refer to the relevant Twig file for adjusting this markup.
+*/
+
 ?>
 <a class="c-button <?php echo esc_attr( $modifier_class ?? '' ); ?>" href="<?php echo esc_url( $c_button_url ?? '' ); ?>">
 	<?php echo esc_html( $c_button_text ?? '' ); ?>

--- a/packages/twig-to-php-parser/__tests__/fixtures/template-parts-expected/patterns/components/c-byline.php
+++ b/packages/twig-to-php-parser/__tests__/fixtures/template-parts-expected/patterns/components/c-byline.php
@@ -1,5 +1,10 @@
 <?php
-// This is a generated file. Refer to the relevant Twig file for adjusting this markup.
+/**
+* Generated file.
+*
+* Refer to the relevant Twig file for adjusting this markup.
+*/
+
 ?>
 <p class="c-byline <?php echo esc_attr( $modifier_class ?? '' ); ?> <?php echo esc_attr( $c_byline_classes ?? '' ); ?>">
 	<?php echo esc_html( $c_byline_by_text ?? '' ); ?>

--- a/packages/twig-to-php-parser/__tests__/fixtures/template-parts-expected/patterns/components/c-heading.php
+++ b/packages/twig-to-php-parser/__tests__/fixtures/template-parts-expected/patterns/components/c-heading.php
@@ -1,4 +1,9 @@
 <?php
-// This is a generated file. Refer to the relevant Twig file for adjusting this markup.
+/**
+* Generated file.
+*
+* Refer to the relevant Twig file for adjusting this markup.
+*/
+
 ?>
 <h2 class="c-heading <?php echo esc_attr( $modifier_class ?? '' ); ?>"><?php echo esc_html( $c_heading_text ?? '' ); ?></h2>

--- a/packages/twig-to-php-parser/__tests__/fixtures/template-parts-expected/patterns/components/c-logo.php
+++ b/packages/twig-to-php-parser/__tests__/fixtures/template-parts-expected/patterns/components/c-logo.php
@@ -1,5 +1,10 @@
 <?php
-// This is a generated file. Refer to the relevant Twig file for adjusting this markup.
+/**
+* Generated file.
+*
+* Refer to the relevant Twig file for adjusting this markup.
+*/
+
 ?>
 <div>
 	<?php \PMC::render_template( \PMC\Larva\Config::get_instance()->get( 'brand_directory' ) . '/build/svg/' . ( $c_logo_svg ?? '' ) . '.svg', [], true ); ?>

--- a/packages/twig-to-php-parser/__tests__/fixtures/template-parts-expected/patterns/components/c-nav-link.php
+++ b/packages/twig-to-php-parser/__tests__/fixtures/template-parts-expected/patterns/components/c-nav-link.php
@@ -1,5 +1,10 @@
 <?php
-// This is a generated file. Refer to the relevant Twig file for adjusting this markup.
+/**
+* Generated file.
+*
+* Refer to the relevant Twig file for adjusting this markup.
+*/
+
 ?>
 <a class="c-nav-link <?php echo esc_attr( $c_nav_link_classes ?? '' ); ?>" href="<?php echo esc_url( $c_nav_link_url ?? '' ); ?>">
 	<?php echo esc_html( $c_nav_link_text ?? '' ); ?>

--- a/packages/twig-to-php-parser/__tests__/fixtures/template-parts-expected/patterns/modules/array-key-in-loop.php
+++ b/packages/twig-to-php-parser/__tests__/fixtures/template-parts-expected/patterns/modules/array-key-in-loop.php
@@ -1,5 +1,10 @@
 <?php
-// This is a generated file. Refer to the relevant Twig file for adjusting this markup.
+/**
+* Generated file.
+*
+* Refer to the relevant Twig file for adjusting this markup.
+*/
+
 ?>
 <?php foreach ( $list_items ?? [] as $item ) { ?>
 	<li class="list__item larva // <?php echo esc_attr( $list_item_classes ?? '' ); ?>">

--- a/packages/twig-to-php-parser/__tests__/fixtures/template-parts-expected/patterns/modules/breadcrumbs.php
+++ b/packages/twig-to-php-parser/__tests__/fixtures/template-parts-expected/patterns/modules/breadcrumbs.php
@@ -1,4 +1,9 @@
 <?php
-// This is a generated file. Refer to the relevant Twig file for adjusting this markup.
+/**
+* Generated file.
+*
+* Refer to the relevant Twig file for adjusting this markup.
+*/
+
 ?>
 <?php \PMC\Larva\Pattern::get_instance()->render_pattern_template( 'objects/o-nav', $o_nav, true ); ?>

--- a/packages/twig-to-php-parser/__tests__/fixtures/template-parts-expected/patterns/modules/html-tag-interpolation.php
+++ b/packages/twig-to-php-parser/__tests__/fixtures/template-parts-expected/patterns/modules/html-tag-interpolation.php
@@ -1,5 +1,10 @@
 <?php
-// This is a generated file. Refer to the relevant Twig file for adjusting this markup.
+/**
+* Generated file.
+*
+* Refer to the relevant Twig file for adjusting this markup.
+*/
+
 ?>
 <<?php echo esc_attr( $list_type_name ?? '' ); ?>l class="list larva // <?php echo esc_attr( $list_classes ?? '' ); ?>">
 	<?php foreach ( $list_items ?? [] as $item ) { ?>

--- a/packages/twig-to-php-parser/__tests__/fixtures/template-parts-expected/patterns/modules/trending.php
+++ b/packages/twig-to-php-parser/__tests__/fixtures/template-parts-expected/patterns/modules/trending.php
@@ -1,5 +1,10 @@
 <?php
-// This is a generated file. Refer to the relevant Twig file for adjusting this markup.
+/**
+* Generated file.
+*
+* Refer to the relevant Twig file for adjusting this markup.
+*/
+
 ?>
 <section class="u-max-width-300">
 	<header>

--- a/packages/twig-to-php-parser/__tests__/fixtures/template-parts-expected/patterns/objects/o-crap.php
+++ b/packages/twig-to-php-parser/__tests__/fixtures/template-parts-expected/patterns/objects/o-crap.php
@@ -1,4 +1,9 @@
 <?php
-// This is a generated file. Refer to the relevant Twig file for adjusting this markup.
+/**
+* Generated file.
+*
+* Refer to the relevant Twig file for adjusting this markup.
+*/
+
 ?>
 <p class="o-crap <?php echo esc_attr( $modifier_class ?? '' ); ?> <?php echo esc_attr( $o_crap_classes ?? '' ); ?>"><?php echo esc_html( $o_crap_text ?? '' ); ?></p>

--- a/packages/twig-to-php-parser/__tests__/fixtures/template-parts-expected/patterns/objects/o-nav.php
+++ b/packages/twig-to-php-parser/__tests__/fixtures/template-parts-expected/patterns/objects/o-nav.php
@@ -1,5 +1,10 @@
 <?php
-// This is a generated file. Refer to the relevant Twig file for adjusting this markup.
+/**
+* Generated file.
+*
+* Refer to the relevant Twig file for adjusting this markup.
+*/
+
 ?>
 <nav class="o-nav <?php echo esc_attr( $modifier_class ?? '' ); ?> <?php echo esc_attr( $o_nav_classes ?? '' ); ?>" data-dropdown="<?php echo esc_attr( $o_nav_data_attributes ?? '' ); ?>">
 

--- a/packages/twig-to-php-parser/__tests__/fixtures/template-parts-expected/patterns/objects/o-story-list.php
+++ b/packages/twig-to-php-parser/__tests__/fixtures/template-parts-expected/patterns/objects/o-story-list.php
@@ -1,5 +1,10 @@
 <?php
-// This is a generated file. Refer to the relevant Twig file for adjusting this markup.
+/**
+* Generated file.
+*
+* Refer to the relevant Twig file for adjusting this markup.
+*/
+
 ?>
 <ul class="o-story-list <?php echo esc_attr( $modifier_class ?? '' ); ?> <?php echo esc_attr( $o_story_list_classes ?? '' ); ?>">
 	<?php foreach ( $o_story_list_teases ?? [] as $item ) { ?>

--- a/packages/twig-to-php-parser/lib/twig-to-php-parser.php
+++ b/packages/twig-to-php-parser/lib/twig-to-php-parser.php
@@ -216,7 +216,7 @@ function twig_to_php_parser( $patterns_dir_path, $template_dir_path, $is_using_p
 		$twig_markup_replace_main     = parse_wp_action( $twig_markup_replace_main );
 		$twig_markup_replace_complete = str_replace( array_keys( (array) $general_replacers ), array_values( $general_replacers ), $twig_markup_replace_main );
 
-		$php_markup  = "<?php\n// This is a generated file. Refer to the relevant Twig file for adjusting this markup.\n?>\n";
+		$php_markup  = "<?php\n/**\n* Generated file.\n*\n* Refer to the relevant Twig file for adjusting this markup.\n*/\n\n?>";
 		$php_markup .= $twig_markup_replace_complete;
 
 		if ( ! file_exists( $template_dir ) ) {

--- a/packages/twig-to-php-parser/lib/twig-to-php-parser.php
+++ b/packages/twig-to-php-parser/lib/twig-to-php-parser.php
@@ -216,7 +216,7 @@ function twig_to_php_parser( $patterns_dir_path, $template_dir_path, $is_using_p
 		$twig_markup_replace_main     = parse_wp_action( $twig_markup_replace_main );
 		$twig_markup_replace_complete = str_replace( array_keys( (array) $general_replacers ), array_values( $general_replacers ), $twig_markup_replace_main );
 
-		$php_markup  = "<?php\n/**\n* Generated file.\n*\n* Refer to the relevant Twig file for adjusting this markup.\n*/\n\n?>";
+		$php_markup  = "<?php\n/**\n* Generated file.\n*\n* Refer to the relevant Twig file for adjusting this markup.\n*/\n\n?>\n";
 		$php_markup .= $twig_markup_replace_complete;
 
 		if ( ! file_exists( $template_dir ) ) {


### PR DESCRIPTION
Modified the structure of generated comments to adhere to filedoc standard.

### Make sure you complete these items:

- [x] Updated root CHANGELOG.md with summary of changes under `Unpublished` section
- [x] `npm run prod` in this repo outputs expected changes (excepting the issue with re-ordered partials in larva-css algorithms partials - see [LRVA-1885](https://jira.pmcdev.io/browse/LRVA-1885))