### PR TITLE
moves unpublished comments to new version, changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unpublished
+
+## 1.4.0 - 6-03-2022
 * larva-patterns - Add `narrow` variant for `paragraph` module.
 * larva-patterns - Add `xl` variant for `top-stories` module.
-* larva-patterns - Updates to  `story-featured-quote` module.
 * larva-patterns - Add `article-timestamp` module.
+* larva-patterns - Updates to  `story-featured-quote` module.1
 
 ## 1.3.0 - 5-25-2022
 * larva-css - Add `lrv-u-filter-grayscale-100` class.


### PR DESCRIPTION
<!-- Add a summary of your changes here -->

### Make sure you complete these items:

- [ ] Updated root CHANGELOG.md with summary of changes under `Unpublished` section
- [ ] `npm run prod` in this repo outputs expected changes (excepting the issue with re-ordered partials in larva-css algorithms partials - see [LRVA-1885](https://jira.pmcdev.io/browse/LRVA-1885))
- [ ] If adding a new pattern, in the PR comment, included a screenshot and link to the static Vercel deployment
- [ ] If changes to build scripts or the Node.js server, tested changes in pmc-spark [via a pre-release](https://confluence.pmcdev.io/x/XhOeAw)
- - If changes to build tools: npm scripts `prod`, `lint`, and `dev` scripts run as expected
- - If changes to Larva server: Static site generates as expected in a theme  (avail. on a URL {brand}.stg.larva.pmcdev.io)