### PR TITLE
Support webpack externals in Larva config

### DIFF
--- a/packages/larva/scripts/config/webpack.config.js
+++ b/packages/larva/scripts/config/webpack.config.js
@@ -14,6 +14,8 @@ const aliases = {
 	... getConfig( 'webpack' ).aliases
 };
 
+const externals = getConfig( 'webpack' ).externals ?? {};
+
 const eslintConfig = getConfig( 'eslint', true );
 const eslintConfigFile = undefined !== eslintConfig ? eslintConfig.configFile : null;
 
@@ -71,6 +73,7 @@ const config = {
 	resolve: {
 		alias: aliases
 	},
+	externals,
 	optimization: {
 		minimize: true
 	}


### PR DESCRIPTION
If a Larva script will use a package provided by WordPress, such as lodash or
any `@wordpress`-prefixed package, it should be declared as an external in the
Larva config otherwise webpack will either error because it can't resolve the
module or will require that we bundle one of those packages in the module. By
allowing consuming projects to specify externals, those packages can be
sourced from WordPress.

### Make sure you complete these items:

- [ ] Updated root CHANGELOG.md with summary of changes under `Unpublished` section
- [ ] `npm run prod` in this repo outputs expected changes (excepting the issue with re-ordered partials in larva-css algorithms partials - see [LRVA-1885](https://jira.pmcdev.io/browse/LRVA-1885))
- [ ] If adding a new pattern, in the PR comment, included a screenshot and link to the static Vercel deployment
- [ ] If changes to build scripts or the Node.js server, tested changes in pmc-spark [via a pre-release](https://confluence.pmcdev.io/x/XhOeAw)
- - If changes to build tools: npm scripts `prod`, `lint`, and `dev` scripts run as expected
- - If changes to Larva server: Static site generates as expected in a theme  (avail. on a URL {brand}.stg.larva.pmcdev.io)

<sup> Created from JetBrains using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>