### PR TITLE
Add image decoding attribute support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * larva-patterns - Add `table` module.
 * larva-patterns - Add `gallery` module.
 * larva-tokens - Minify tokens CSS files.
+* larva-patters - Add image `decoding` attribute.
 
 ## 1.17.0
 * larva-tokens - Update Basic XS font tokens for rollingstone-2022.

--- a/packages/larva-patterns/components/c-lazy-image/c-lazy-image.prototype.js
+++ b/packages/larva-patterns/components/c-lazy-image/c-lazy-image.prototype.js
@@ -13,5 +13,23 @@ module.exports = {
 	c_lazy_image_img_classes: 'lrv-u-background-color-grey-lightest lrv-u-width-100p lrv-u-display-block lrv-u-height-auto',
 	c_lazy_image_height_attr: '',
 	c_lazy_image_width_attr: '',
+	c_lazy_image_in_initial_viewport: false,
+	c_lazy_image_decoding_attr: 'async'
+}
+module.exports = {
+	c_lazy_image_classes: '',
+	c_lazy_image_link_url: false,
+	c_lazy_image_link_classes: 'lrv-a-unstyle-link',
+	c_lazy_image_crop_class: 'lrv-a-crop-16x9',
+	c_lazy_image_crop_style_attr: false,
+	c_lazy_image_link_tab_index_attr: false,
+	c_lazy_image_alt_attr: 'Lazy loaded image',
+	c_lazy_image_src_url: 'https://farm5.staticflickr.com/4078/5441060528_31db7838ba_z.jpg',
+	c_lazy_image_placeholder_url: 'data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==',
+	c_lazy_image_srcset_attr: 'https://farm5.staticflickr.com/4078/5441060528_31db7838ba_m.jpg 240w,https://farm5.staticflickr.com/4078/5441060528_31db7838ba_n.jpg 320w,https://farm5.staticflickr.com/4078/5441060528_31db7838ba.jpg 500w,https://farm5.staticflickr.com/4078/5441060528_31db7838ba_z.jpg 640w,https://farm5.staticflickr.com/4078/5441060528_31db7838ba_b.jpg 1024w',
+	c_lazy_image_sizes_attr: 'auto',
+	c_lazy_image_img_classes: 'lrv-u-background-color-grey-lightest lrv-u-width-100p lrv-u-display-block lrv-u-height-auto',
+	c_lazy_image_height_attr: '',
+	c_lazy_image_width_attr: '',
 	c_lazy_image_in_initial_viewport: false
 }

--- a/packages/larva-patterns/components/c-lazy-image/c-lazy-image.prototype.js
+++ b/packages/larva-patterns/components/c-lazy-image/c-lazy-image.prototype.js
@@ -16,20 +16,3 @@ module.exports = {
 	c_lazy_image_in_initial_viewport: false,
 	c_lazy_image_decoding_attr: 'async'
 }
-module.exports = {
-	c_lazy_image_classes: '',
-	c_lazy_image_link_url: false,
-	c_lazy_image_link_classes: 'lrv-a-unstyle-link',
-	c_lazy_image_crop_class: 'lrv-a-crop-16x9',
-	c_lazy_image_crop_style_attr: false,
-	c_lazy_image_link_tab_index_attr: false,
-	c_lazy_image_alt_attr: 'Lazy loaded image',
-	c_lazy_image_src_url: 'https://farm5.staticflickr.com/4078/5441060528_31db7838ba_z.jpg',
-	c_lazy_image_placeholder_url: 'data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==',
-	c_lazy_image_srcset_attr: 'https://farm5.staticflickr.com/4078/5441060528_31db7838ba_m.jpg 240w,https://farm5.staticflickr.com/4078/5441060528_31db7838ba_n.jpg 320w,https://farm5.staticflickr.com/4078/5441060528_31db7838ba.jpg 500w,https://farm5.staticflickr.com/4078/5441060528_31db7838ba_z.jpg 640w,https://farm5.staticflickr.com/4078/5441060528_31db7838ba_b.jpg 1024w',
-	c_lazy_image_sizes_attr: 'auto',
-	c_lazy_image_img_classes: 'lrv-u-background-color-grey-lightest lrv-u-width-100p lrv-u-display-block lrv-u-height-auto',
-	c_lazy_image_height_attr: '',
-	c_lazy_image_width_attr: '',
-	c_lazy_image_in_initial_viewport: false
-}

--- a/packages/larva-patterns/components/c-lazy-image/c-lazy-image.twig
+++ b/packages/larva-patterns/components/c-lazy-image/c-lazy-image.twig
@@ -15,9 +15,9 @@
 		{{ c_lazy_image_markup }}
 	{% else %}
 		{% if c_lazy_image_in_initial_viewport %}
-			<img class="c-lazy-image__img {{ c_lazy_image_img_classes }}" src="{{ c_lazy_image_src_url }}" alt="{{ c_lazy_image_alt_attr }}" srcset="{{ c_lazy_image_srcset_attr }}" sizes="{{ c_lazy_image_sizes_attr }}" height="{{ c_lazy_image_height_attr }}" width="{{ c_lazy_image_width_attr }}">
+			<img class="c-lazy-image__img {{ c_lazy_image_img_classes }}" src="{{ c_lazy_image_src_url }}" alt="{{ c_lazy_image_alt_attr }}" srcset="{{ c_lazy_image_srcset_attr }}" sizes="{{ c_lazy_image_sizes_attr }}" height="{{ c_lazy_image_height_attr }}" width="{{ c_lazy_image_width_attr }}" decoding="{{ c_lazy_image_decoding_attr }}">
 		{% else %}
-			<img class="c-lazy-image__img {{ c_lazy_image_img_classes }}" src="{{ c_lazy_image_placeholder_url }}" data-lazy-src="{{ c_lazy_image_src_url }}" alt="{{ c_lazy_image_alt_attr }}" data-lazy-srcset="{{ c_lazy_image_srcset_attr }}" data-lazy-sizes="{{ c_lazy_image_sizes_attr }}" height="{{ c_lazy_image_height_attr }}" width="{{ c_lazy_image_width_attr }}">
+			<img class="c-lazy-image__img {{ c_lazy_image_img_classes }}" src="{{ c_lazy_image_placeholder_url }}" data-lazy-src="{{ c_lazy_image_src_url }}" alt="{{ c_lazy_image_alt_attr }}" data-lazy-srcset="{{ c_lazy_image_srcset_attr }}" data-lazy-sizes="{{ c_lazy_image_sizes_attr }}" height="{{ c_lazy_image_height_attr }}" width="{{ c_lazy_image_width_attr }}" decoding="{{ c_lazy_image_decoding_attr }}">
 		{% endif %}
 	{% endif %}
 


### PR DESCRIPTION
<!-- Add a summary of your changes here -->
Add image decoding attribute support.

![image](https://user-images.githubusercontent.com/70001872/182757715-2b3eeb44-a20c-4bab-ad89-4f62b506f5ce.png)

### Make sure you complete these items:

- [ ] Updated root CHANGELOG.md with summary of changes under `Unpublished` section
- [ ] `npm run prod` in this repo outputs expected changes (excepting the issue with re-ordered partials in larva-css algorithms partials - see [LRVA-1885](https://jira.pmcdev.io/browse/LRVA-1885))
- [ ] If adding a new pattern, in the PR comment, included a screenshot and link to the static Vercel deployment
- [ ] If changes to build scripts or the Node.js server, tested changes in pmc-spark [via a pre-release](https://confluence.pmcdev.io/x/XhOeAw)
- - If changes to build tools: npm scripts `prod`, `lint`, and `dev` scripts run as expected
- - If changes to Larva server: Static site generates as expected in a theme  (avail. on a URL {brand}.stg.larva.pmcdev.io)