### PR TITLE
Preparing for the Larva release v1.31.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unpublished Changes
+
+## 1.31.0 09-19-2022
 * larva-patterns - Add `newsletter_cta_inner_classes` variable to newsletter CTA inner wrapper.
-* larva-patterns - Add `c_timestamp_markup` varaiable to timestamp component.
+* larva-patterns - Add `c_timestamp_markup` variable to timestamp component.
 * larva-patterns - Update `heading` & `post-content-image` module to include animation class.
 
 ## 1.30.0 09-15-2022


### PR DESCRIPTION
<!-- Add a summary of your changes here -->

### Make sure you complete these items:

- [ ] Updated root CHANGELOG.md with summary of changes under `Unpublished` section
- [ ] `npm run prod` in this repo outputs expected changes (excepting the issue with re-ordered partials in larva-css algorithms partials - see [LRVA-1885](https://jira.pmcdev.io/browse/LRVA-1885))
- [ ] If adding a new pattern, in the PR comment, included a screenshot and link to the static Vercel deployment
- [ ] If changes to build scripts or the Node.js server, tested changes in pmc-spark [via a pre-release](https://confluence.pmcdev.io/x/XhOeAw)
- - If changes to build tools: npm scripts `prod`, `lint`, and `dev` scripts run as expected
- - If changes to Larva server: Static site generates as expected in a theme  (avail. on a URL {brand}.stg.larva.pmcdev.io)