### PR TITLE
Initial auto npm release workflow

### DIFF
--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -1,0 +1,50 @@
+# This is a basic workflow to help you get started with Actions
+
+name: Release to npm
+
+# -- steps for larva release, for reference
+# this action would be triggered by: a button in the Actions tab
+# start at the master branch
+# checkout a release branch from master, 
+  # increment the name (assume minor releases most of the time) by reading lerna json file
+  # run git checkout
+# assume changelog has been updated
+# run npx lerna publish
+  # asks if minor/major release, user has to manually type. probably https://github.com/lerna/lerna/tree/main/commands/version#options
+  # try running npx lerna publish minor --yes
+# create a PR to merge release branch to master
+  # at least one human approval required (nice to have: auto ping #larva channel asking for PR approval)
+  # pipelines have to pass
+  # manual merge required (nice to have: have a machine user w/ token in the allowlist that can bypass)
+# tag latest release on repo
+
+# Controls when the workflow will run
+on:
+  # Allows you to run this workflow manually from the Actions tab
+  # docs: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch
+  # https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow
+  workflow_dispatch:
+  
+  
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v3
+
+      # Runs a single command using the runners shell
+      - name: Run a one-line script
+        run: echo Hello, world!
+
+      # Runs a set of commands using the runners shell
+      - name: Run a multi-line script
+        run: |
+          echo Add other actions to build,
+          echo test, and deploy your project.


### PR DESCRIPTION
As of 10/4 working group discussion.
- wrote out the steps for a larva release, discussed what can be automated and what cannot
- started reading into workflow_dispatch that triggers the release

### Make sure you complete these items:

- [ ] Updated root CHANGELOG.md with summary of changes under `Unpublished` section
- [ ] `npm run prod` in this repo outputs expected changes (excepting the issue with re-ordered partials in larva-css algorithms partials - see [LRVA-1885](https://jira.pmcdev.io/browse/LRVA-1885))
- [ ] If adding a new pattern, in the PR comment, included a screenshot and link to the static Vercel deployment
- [ ] If changes to build scripts or the Node.js server, tested changes in pmc-spark [via a pre-release](https://confluence.pmcdev.io/x/XhOeAw)
- - If changes to build tools: npm scripts `prod`, `lint`, and `dev` scripts run as expected
- - If changes to Larva server: Static site generates as expected in a theme  (avail. on a URL {brand}.stg.larva.pmcdev.io)