### PR TITLE
Add c-title link target attr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unpublished Changes
+* larva-patterns - Add `c-title` link attr.
 
 ## 1.37.6 10-31-2022
 * larva-tokens - Update larva tokens for font primary on mobile.

--- a/packages/larva-patterns/components/c-title/c-title.twig
+++ b/packages/larva-patterns/components/c-title/c-title.twig
@@ -11,7 +11,11 @@
 	{% endif %}
 
 	{% if c_title_url %}
-		<a href="{{ c_title_url }}" class="c-title__link {{ c_title_link_classes }}"  {{ c_title_link_data_attr }}>
+		<a href="{{ c_title_url }}" class="c-title__link {{ c_title_link_classes }}"
+		{% if c_title_url_target_blank %}
+			target="_blank" rel="noopener noreferrer"
+		{% endif %}
+		{{ c_title_link_data_attr }}>
 	{% endif %}
 
 		{% if c_title_before_text %}


### PR DESCRIPTION
<!-- Add a summary of your changes here -->

### Make sure you complete these items:

- [X] Updated root CHANGELOG.md with summary of changes under `Unpublished` section
- [ ] `npm run prod` in this repo outputs expected changes (excepting the issue with re-ordered partials in larva-css algorithms partials - see [LRVA-1885](https://jira.pmcdev.io/browse/LRVA-1885))
- [ ] If adding a new pattern, in the PR comment, included a screenshot and link to the static Vercel deployment
- [ ] If changes to build scripts or the Node.js server, tested changes in pmc-spark [via a pre-release](https://confluence.pmcdev.io/x/XhOeAw)
- - If changes to build tools: npm scripts `prod`, `lint`, and `dev` scripts run as expected
- - If changes to Larva server: Static site generates as expected in a theme  (avail. on a URL {brand}.stg.larva.pmcdev.io)