### PR TITLE
BR-2180: Add pullquote module variant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unpublished Changes
+* larva-patterns - Add `hubs` variant to `pullquote` module.
 
 ## 1.42.1 01-24-2023
 * larva-scss - Use `round` func when generating font size utility classes (via `@mixin u-font-size`) to prevent errors when converting rems to pixels for class name.

--- a/packages/larva-patterns/modules/pullquote/pullquote.hubs.js
+++ b/packages/larva-patterns/modules/pullquote/pullquote.hubs.js
@@ -1,0 +1,6 @@
+const clonedeep = require( 'lodash.clonedeep' );
+const pullquote = clonedeep( require( './pullquote.prototype' ) );
+
+pullquote.pullquote_classes = 'hubs-pullquote lrv-u-width-100p lrv-u-margin-a-00';
+
+module.exports = pullquote;


### PR DESCRIPTION
- Add variant `hubs` to `pullquote` module. Needed for Billboard Hubs which has a specific design that is different from pullquote module used in articles or other post types.
- Made styles generic so other brand hubs can use in future. Specific styles to be added at theme level.
- Ticket ref: [https://penskemedia.atlassian.net/browse/BR-2180](https://penskemedia.atlassian.net/browse/BR-2180)

### Make sure you complete these items:

- [x] Updated root CHANGELOG.md with summary of changes under `Unpublished` section
- [x] `npm run prod` in this repo outputs expected changes (excepting the issue with re-ordered partials in larva-css algorithms partials - see [LRVA-1885](https://jira.pmcdev.io/browse/LRVA-1885))
- [ ] If adding a new pattern, in the PR comment, included a screenshot and link to the static Vercel deployment
- [ ] If changes to build scripts or the Node.js server, tested changes in pmc-spark [via a pre-release](https://confluence.pmcdev.io/x/XhOeAw)
- - If changes to build tools: npm scripts `prod`, `lint`, and `dev` scripts run as expected
- - If changes to Larva server: Static site generates as expected in a theme  (avail. on a URL {brand}.stg.larva.pmcdev.io)