### PR TITLE
[PASE-1408] SEO: CORE TECH - Roll out Smart 404 to ARTnews, Sportico, Dirt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unpublished Changes
 * larva-svg - Updated Flipboard logomark with 2023 version.
+* larva-patterns - Add `smart` variant for `page-404` module.
 
 ## 1.48.1 04-25-2023
 * Re-build larva JSON/versioning

--- a/packages/larva-patterns/modules/page-404/page-404.prototype.js
+++ b/packages/larva-patterns/modules/page-404/page-404.prototype.js
@@ -1,62 +1,49 @@
 const clonedeep = require( 'lodash.clonedeep' );
 
 const c_heading_prototype = require( '@penskemediacorp/larva-patterns/components/c-heading/c-heading.prototype' );
-const c_svg_prototype = require( '../../components/c-svg/c-svg.prototype.js' );
-const c_title_prototype = require( '@penskemediacorp/larva-patterns/components/c-title/c-title.prototype' );
-const c_tagline_prototype = require( '@penskemediacorp/larva-patterns/components/c-tagline/c-tagline.prototype' );
-const suggested_link_items_prototype = require( '@penskemediacorp/larva-patterns/modules/list/list.prototype' );
-const search_form_prototype = require( '@penskemediacorp/larva-patterns/modules/search-form/search-form.prototype' );
-
 const c_heading = clonedeep( c_heading_prototype );
-const c_suggestion_title = clonedeep( c_title_prototype );
-const c_search_title = clonedeep( c_title_prototype );
-const c_svg = clonedeep( c_svg_prototype );
-const c_title = clonedeep( c_title_prototype );
-const c_tagline = clonedeep( c_tagline_prototype );
-const suggested_link_items = clonedeep( suggested_link_items_prototype );
-const search_form = clonedeep( search_form_prototype );
 
+const c_svg_prototype = require( '../../components/c-svg/c-svg.prototype.js' );
+const c_svg = clonedeep( c_svg_prototype );
+
+const c_title_prototype = require( '@penskemediacorp/larva-patterns/components/c-title/c-title.prototype' );
+const c_title = clonedeep( c_title_prototype );
+
+const c_button_prototype = require( '@penskemediacorp/larva-patterns/components/c-button/c-button.prototype' );
+const c_button_home = clonedeep( c_button_prototype );
+const c_button_search = clonedeep( c_button_prototype );
+
+c_heading.c_heading_text = '404';
 c_heading.c_heading_classes = 'lrv-a-screen-reader-only';
 c_heading.c_heading_is_primary_heading = true;
-c_heading.c_heading_text = '404';
 
 c_svg.c_svg_name = 'logo-404';
 c_svg.c_svg_classes = 'lrv-u-max-width-100p';
 
 c_title.c_title_text = 'OOPS! Something went wrong here!';
-c_title.c_title_classes = 'lrv-a-font-secondary-l lrv-u-text-transform-uppercase lrv-u-margin-b-125';
+c_title.c_title_classes =
+	'lrv-a-font-secondary-l lrv-u-text-transform-uppercase lrv-u-margin-b-125';
 c_title.c_title_url = false;
 
-c_suggestion_title.c_title_classes = 'lrv-u-text-align-left lrv-u-margin-b-075';
-c_suggestion_title.c_title_text = 'Here are some suggestions that might be the page you were looking for:';
-c_suggestion_title.c_title_url = false;
+c_button_home.c_button_text = 'Back To Homepage';
+c_button_home.c_button_url = '/';
+c_button_home.c_button_classes +=
+	' lrv-u-background-color-black lrv-u-margin-lr-075 lrv-u-text-transform-uppercase lrv-u-font-weight-bold u-background-color-brand-primary-dark:hover lrv-u-color-white lrv-u-color-white:hover lrv-u-padding-tb-050 lrv-u-padding-lr-1';
 
-suggested_link_items.list_classes = 'lrv-u-text-align-left lrv-u-padding-b-1';
-suggested_link_items.list_items = [
-	{ list_markup: 'item_one' },
-	{ list_markup: 'item_two' },
-];
-
-c_search_title.c_title_classes = 'lrv-u-text-align-left';
-c_search_title.c_title_text = 'Or try searching for it here...';
-c_search_title.c_title_url = false;
-
-search_form.search_form_classes = 'lrv-u-text-align-left lrv-u-margin-t-1 search-form-404';
-search_form.search_form_input_classes = 'lrv-u-border-a-1 lrv-u-width-100p';
-search_form.search_form_action_url = '/?s=';
+c_button_search.c_button_text = 'Head To Search';
+c_button_search.c_button_url = '#';
+c_button_search.c_button_classes +=
+	' lrv-u-background-color-black lrv-u-margin-lr-075 lrv-u-text-transform-uppercase lrv-u-font-weight-bold u-background-color-brand-primary-dark:hover lrv-u-color-white lrv-u-color-white:hover lrv-u-padding-tb-050 lrv-u-padding-lr-1 lrv-u-margin-t-050@mobile-max';
 
 module.exports = {
-	button_outer_classes:
-		'lrv-u-flex lrv-u-justify-content-center lrv-u-align-items-center lrv-u-flex-direction-column@mobile-max',
 	c_heading,
-	c_suggestion_title,
-	c_search_title,
-	c_svg,
-	c_tagline,
 	c_title,
-	page_404_inner_classes: 'lrv-u-margin-lr-auto lrv-u-padding-lr-1',
-	search_form,
-	suggested_link_items,
+	c_button_home,
+	c_button_search,
+	c_svg,
 	wrapper_classes:
 		'lrv-u-text-align-center lrv-u-padding-t-1 lrv-u-padding-b-2 lrv-u-margin-b-2 lrv-u-max-width-830 lrv-u-margin-lr-auto',
+	page_404_inner_classes: 'lrv-u-margin-lr-auto lrv-u-padding-lr-1',
+	button_outer_classes:
+		'lrv-u-flex lrv-u-justify-content-center lrv-u-align-items-center lrv-u-flex-direction-column@mobile-max',
 };

--- a/packages/larva-patterns/modules/page-404/page-404.smart.js
+++ b/packages/larva-patterns/modules/page-404/page-404.smart.js
@@ -1,0 +1,60 @@
+const clonedeep = require( 'lodash.clonedeep' );
+
+const c_heading_prototype = require( '@penskemediacorp/larva-patterns/components/c-heading/c-heading.prototype' );
+const c_svg_prototype = require( '../../components/c-svg/c-svg.prototype.js' );
+const c_title_prototype = require( '@penskemediacorp/larva-patterns/components/c-title/c-title.prototype' );
+const c_tagline_prototype = require( '@penskemediacorp/larva-patterns/components/c-tagline/c-tagline.prototype' );
+const suggested_link_items_prototype = require( '@penskemediacorp/larva-patterns/modules/list/list.prototype' );
+const search_form_prototype = require( '@penskemediacorp/larva-patterns/modules/search-form/search-form.prototype' );
+
+const c_heading = clonedeep( c_heading_prototype );
+const c_suggestion_title = clonedeep( c_title_prototype );
+const c_search_title = clonedeep( c_title_prototype );
+const c_svg = clonedeep( c_svg_prototype );
+const c_title = clonedeep( c_title_prototype );
+const c_tagline = clonedeep( c_tagline_prototype );
+const suggested_link_items = clonedeep( suggested_link_items_prototype );
+const search_form = clonedeep( search_form_prototype );
+
+c_heading.c_heading_classes = 'lrv-a-screen-reader-only';
+c_heading.c_heading_is_primary_heading = true;
+c_heading.c_heading_text = '404';
+
+c_svg.c_svg_name = 'logo-404';
+c_svg.c_svg_classes = 'lrv-u-max-width-100p';
+
+c_title.c_title_text = 'OOPS! Something went wrong here!';
+c_title.c_title_classes = 'lrv-a-font-secondary-l lrv-u-text-transform-uppercase lrv-u-margin-b-125';
+c_title.c_title_url = false;
+
+c_suggestion_title.c_title_classes = 'lrv-u-text-align-left lrv-u-margin-b-075';
+c_suggestion_title.c_title_text = 'Here are some suggestions that might be the page you were looking for:';
+c_suggestion_title.c_title_url = false;
+
+suggested_link_items.list_classes = 'lrv-u-text-align-left lrv-u-padding-b-1';
+suggested_link_items.list_items = [
+	{ list_markup: 'item_one' },
+	{ list_markup: 'item_two' },
+];
+
+c_search_title.c_title_classes = 'lrv-u-text-align-left';
+c_search_title.c_title_text = 'Or try searching for it here...';
+c_search_title.c_title_url = false;
+
+search_form.search_form_classes = 'lrv-u-text-align-left lrv-u-margin-t-1 lrv-u-display-inline-flex lrv-u-width-100p search-form-404';
+search_form.search_form_input_classes = 'lrv-u-border-a-1 lrv-u-width-100p';
+search_form.search_form_action_url = '/?s=';
+
+module.exports = {
+	c_heading,
+	c_suggestion_title,
+	c_search_title,
+	c_svg,
+	c_tagline,
+	c_title,
+	page_404_inner_classes: 'lrv-u-margin-lr-auto lrv-u-padding-lr-1',
+	search_form,
+	suggested_link_items,
+	wrapper_classes:
+		'lrv-u-text-align-center lrv-u-padding-t-1 lrv-u-padding-b-2 lrv-u-margin-b-2 lrv-u-max-width-830 lrv-u-margin-lr-auto',
+};

--- a/packages/larva-patterns/modules/page-404/page-404.twig
+++ b/packages/larva-patterns/modules/page-404/page-404.twig
@@ -16,19 +16,17 @@
 			{% include "@larva/components/c-tagline/c-tagline.twig" with c_tagline %}
 		{% endif %}
 
-		{% if c_button_home or c_button_search %}
-			<div class="buttons-outer {{ button_outer_classes }}">
+		<div class="buttons-outer {{ button_outer_classes }}">
 
-				{% if c_button_home %}
-					{% include "@larva/components/c-button/c-button.twig" with c_button_home %}
-				{% endif %}
+			{% if c_button_home %}
+				{% include "@larva/components/c-button/c-button.twig" with c_button_home %}
+			{% endif %}
 
-				{% if c_button_search %}
-					{% include "@larva/components/c-button/c-button.twig" with c_button_search %}
-				{% endif %}
+			{% if c_button_search %}
+				{% include "@larva/components/c-button/c-button.twig" with c_button_search %}
+			{% endif %}
 
-			</div>
-		{% endif %}
+		</div>
 
 		{% if c_suggestion_title %}
 			{% include "@larva/components/c-title/c-title.twig" with c_suggestion_title %}

--- a/packages/larva-patterns/modules/page-404/page-404.twig
+++ b/packages/larva-patterns/modules/page-404/page-404.twig
@@ -16,6 +16,20 @@
 			{% include "@larva/components/c-tagline/c-tagline.twig" with c_tagline %}
 		{% endif %}
 
+		{% if c_button_home or c_button_search %}
+			<div class="buttons-outer {{ button_outer_classes }}">
+
+				{% if c_button_home %}
+					{% include "@larva/components/c-button/c-button.twig" with c_button_home %}
+				{% endif %}
+
+				{% if c_button_search %}
+					{% include "@larva/components/c-button/c-button.twig" with c_button_search %}
+				{% endif %}
+
+			</div>
+		{% endif %}
+
 		{% if c_suggestion_title %}
 			{% include "@larva/components/c-title/c-title.twig" with c_suggestion_title %}
 		{% endif %}


### PR DESCRIPTION
Summary
---
This PR, when enabled,
- Adds smart prototype for `page-404` module.

[Previous PR](https://github.com/penske-media-corp/pmc-larva/pull/788) to `page-404` module has replaced buttons with suggested links. Now the need has changed to roll out Smart 404 incrementally across brands, so it requires both prototypes (with buttons and with suggested links) to run simultaneously. Hence we are adding Suggested Links as a separate prototype to run both versions side-by-side.

Issue url or additional context
---
https://penskemedia.atlassian.net/browse/1408

### Make sure you complete these items:

- [x] Updated root CHANGELOG.md with summary of changes under `Unpublished` section
- [x] `npm run prod` in this repo outputs expected changes (excepting the issue with re-ordered partials in larva-css algorithms partials - see [LRVA-1885](https://jira.pmcdev.io/browse/LRVA-1885))
- [ ] If adding a new pattern, in the PR comment, included a screenshot and link to the static Vercel deployment
- [ ] If changes to build scripts or the Node.js server, tested changes in pmc-spark [via a pre-release](https://confluence.pmcdev.io/x/XhOeAw)
- - If changes to build tools: npm scripts `prod`, `lint`, and `dev` scripts run as expected
- - If changes to Larva server: Static site generates as expected in a theme  (avail. on a URL {brand}.stg.larva.pmcdev.io)