### PR TITLE
Add Vercel workflow

### DIFF
--- a/.github/workflows/vercel.yml
+++ b/.github/workflows/vercel.yml
@@ -12,9 +12,9 @@ jobs:
     uses: penske-media-corp/github-workflows-wordpress/.github/workflows/vercel.yml@main
     secrets:
       VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
       VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
     with:
       VERCEL_ORG_SlUG: 'penske-media-corp'
+      VERCEL_PROJECT_ID: 'QmNsDWT7v4xm3WZ9LoUbwfoMkedvu9Lv6fQe6BtcUGYYG2'
       VERCEL_PROJECT_NAME: 'pmc-larva'
       WORKING_DIRECTORY: './'

--- a/.github/workflows/vercel.yml
+++ b/.github/workflows/vercel.yml
@@ -12,9 +12,9 @@ jobs:
     uses: penske-media-corp/github-workflows-wordpress/.github/workflows/vercel.yml@main
     secrets:
       VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
       VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
     with:
       VERCEL_ORG_SlUG: 'penske-media-corp'
-      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
       VERCEL_PROJECT_NAME: 'pmc-larva'
       WORKING_DIRECTORY: './'

--- a/.github/workflows/vercel.yml
+++ b/.github/workflows/vercel.yml
@@ -1,0 +1,20 @@
+name: Vercel
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  deploy-nova:
+    name: Deploy
+    uses: penske-media-corp/github-workflows-wordpress/.github/workflows/vercel.yml@main
+    secrets:
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+    with:
+      VERCEL_ORG_SlUG: 'penske-media-corp'
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+      VERCEL_PROJECT_NAME: 'pmc-larva'
+      WORKING_DIRECTORY: './'

--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,10 @@
 {
+
+	"github": {
+		"enabled": false,
+		"silent": true
+	},
+	"public": false,
 	"redirects": [
 		{
 			"source": "/tokens",


### PR DESCRIPTION
Switches Vercel deploys to a GitHub action

### Make sure you complete these items:

- [ ] Updated root CHANGELOG.md with summary of changes under `Unpublished` section
- [ ] `npm run prod` in this repo outputs expected changes (excepting the issue with re-ordered partials in larva-css algorithms partials - see [LRVA-1885](https://jira.pmcdev.io/browse/LRVA-1885))
- [ ] If adding a new pattern, in the PR comment, included a screenshot and link to the static Vercel deployment
- [ ] If changes to build scripts or the Node.js server, tested changes in pmc-spark [via a pre-release](https://confluence.pmcdev.io/x/XhOeAw)
- - If changes to build tools: npm scripts `prod`, `lint`, and `dev` scripts run as expected
- - If changes to Larva server: Static site generates as expected in a theme  (avail. on a URL {brand}.stg.larva.pmcdev.io)