### PR TITLE
feature/PMCP-5996: Update heading pattern and add support for ID attr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unpublished Changes
 * larva-patterns - Add brand primary link styles to tag list module.
 * larva-patterns - Reorder css class names of modules starting with letter `c` based on WP coding standards.
+* larva-patterns - Add `id` attribute for `heading` module.
 
 ## 1.56.0 08-15-2023
 * larva-patterns - Reorder css class names of modules starting with letter `a` based on WP coding standards.

--- a/packages/larva-patterns/modules/heading/heading.twig
+++ b/packages/larva-patterns/modules/heading/heading.twig
@@ -1,3 +1,10 @@
 {% if heading_markup %}
-	<h{{ heading_level_text }} class="heading larva // {{ heading_classes }} {{ heading_animation_class }} {{ heading_typography_class }} {{ heading_color_class }} {{ heading_background_color_class }} {{ heading_text_align_class }}">{{ heading_markup }}</h{{ heading_level_text }}>
+	<h{{ heading_level_text }} 
+		{% if heading_id_attr %}
+			id="{{ heading_id_attr }}"
+		{% endif %}
+		class="heading larva // {{ heading_classes }} {{ heading_animation_class }} {{ heading_typography_class }} {{ heading_color_class }} {{ heading_background_color_class }} {{ heading_text_align_class }}"
+	>
+		{{ heading_markup }}
+	</h{{ heading_level_text }}>
 {% endif %}


### PR DESCRIPTION
<!-- Add a summary of your changes here -->

### Make sure you complete these items:

- [x] Updated root CHANGELOG.md with summary of changes under `Unpublished` section
- [x] `npm run prod` in this repo outputs expected changes (excepting the issue with re-ordered partials in larva-css algorithms partials - see [LRVA-1885](https://jira.pmcdev.io/browse/LRVA-1885))
- [ ] If adding a new pattern, in the PR comment, included a screenshot and link to the static Vercel deployment
- [ ] If changes to build scripts or the Node.js server, tested changes in pmc-spark [via a pre-release](https://confluence.pmcdev.io/x/XhOeAw)
- - If changes to build tools: npm scripts `prod`, `lint`, and `dev` scripts run as expected
- - If changes to Larva server: Static site generates as expected in a theme  (avail. on a URL {brand}.stg.larva.pmcdev.io)