### PR TITLE
Switch Webpack config "query" JS rule that's throwing warnings and build errors out for "options"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unpublished Changes
+* Switch Webpack config "query" JS rule that's throwing warnings and build errors out for "options"
 * Updated Backstop reference images to 1.58.0 release.
 
 ## 1.58.0 11-01-2023

--- a/packages/larva/scripts/config/webpack.config.js
+++ b/packages/larva/scripts/config/webpack.config.js
@@ -29,7 +29,6 @@ const rules = {
 	 * JS Loaders
 	 */
 	pre: {
-		enforce: 'pre',
 		test: /\.js$/,
 		exclude: /(node_modules|nobundle|vendor)/,
 	},

--- a/packages/larva/scripts/config/webpack.config.js
+++ b/packages/larva/scripts/config/webpack.config.js
@@ -38,7 +38,7 @@ const rules = {
 		include: SRC_DIR,
 		exclude: /(node_modules|nobundle|vendor)/,
 		loader: 'babel-loader',
-		query: {
+		options: {
 			presets: [ '@babel/preset-env' ],
 		},
 	},


### PR DESCRIPTION
<!-- Add a summary of your changes here -->

### Make sure you complete these items:

- [x] Updated root CHANGELOG.md with summary of changes under `Unpublished` section
- [x] `npm run prod` in this repo outputs expected changes (excepting the issue with re-ordered partials in larva-css algorithms partials - see [LRVA-1885](https://jira.pmcdev.io/browse/LRVA-1885))
- [ ] If adding a new pattern, in the PR comment, included a screenshot and link to the static Vercel deployment
- [ ] If changes to build scripts or the Node.js server, tested changes in pmc-spark [via a pre-release](https://confluence.pmcdev.io/x/XhOeAw)
- - If changes to build tools: npm scripts `prod`, `lint`, and `dev` scripts run as expected
- - If changes to Larva server: Static site generates as expected in a theme  (avail. on a URL {brand}.stg.larva.pmcdev.io)