### PR TITLE
Remove twig parser `console.log` for prior testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unpublished Changes
-* Removed unintened `console.log()` from `twig-to-php-parser`.
+* Removed `console.log()` from `twig-to-php-parser` that was added for testing.
 
 ## 1.58.1 11-06-2023
 * Updated Backstop reference images to 1.58.0 release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unpublished Changes
+* Removed unintened `console.log()` from `twig-to-php-parser`.
 
 ## 1.58.1 11-06-2023
 * Updated Backstop reference images to 1.58.0 release.

--- a/packages/twig-to-php-parser/index.js
+++ b/packages/twig-to-php-parser/index.js
@@ -41,8 +41,6 @@ function twigToPhpParser( config = {} ) {
 		phpDir = config.phpDir;
 	}
 
-	console.log( 'JIMBO IN PARSER', twigDir, phpDir );
-
 	return new Promise( ( resolve, reject ) => {
 		execPhp(
 			path.resolve( __dirname, './lib/twig-to-php-parser.php' ),


### PR DESCRIPTION
Removed a `console.log()` from `twig-to-php-parser` that was recently added for testing/troubleshooting.

### Make sure you complete these items:

- [x] Updated root CHANGELOG.md with summary of changes under `Unpublished` section