### PR TITLE
adds anchor id support for heading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unpublished Changes
+* Adds id attribute support for the `heading.twig` component.
 
 ## 1.58.2 11-13-2023
 * Removed `console.log()` from `twig-to-php-parser` that was added for testing.

--- a/packages/larva-patterns/modules/heading/heading.twig
+++ b/packages/larva-patterns/modules/heading/heading.twig
@@ -1,3 +1,10 @@
 {% if heading_markup %}
-	<h{{ heading_level_text }} class="heading larva // {{ heading_classes }} {{ heading_animation_class }} {{ heading_typography_class }} {{ heading_color_class }} {{ heading_background_color_class }} {{ heading_text_align_class }}">{{ heading_markup }}</h{{ heading_level_text }}>
+	<h{{ heading_level_text }}
+		{% if heading_id_attr %}
+		id="{{ heading_id_attr }}"
+		{% endif %}
+		class="heading larva // {{ heading_classes }} {{ heading_animation_class }} {{ heading_typography_class }} {{ heading_color_class }} {{ heading_background_color_class }} {{ heading_text_align_class }}"
+	>
+		{{ heading_markup }}
+	</h{{ heading_level_text }}>
 {% endif %}


### PR DESCRIPTION
<!-- Add a summary of your changes here -->

### Make sure you complete these items:

- [x] Updated root CHANGELOG.md with summary of changes under `Unpublished` section
- [ ] `npm run prod` in this repo outputs expected changes (excepting the issue with re-ordered partials in larva-css algorithms partials - see [LRVA-1885](https://jira.pmcdev.io/browse/LRVA-1885))
- [ ] If adding a new pattern, in the PR comment, included a screenshot and link to the static Vercel deployment
- [ ] If changes to build scripts or the Node.js server, tested changes in pmc-spark [via a pre-release](https://confluence.pmcdev.io/x/XhOeAw)
- - If changes to build tools: npm scripts `prod`, `lint`, and `dev` scripts run as expected
- - If changes to Larva server: Static site generates as expected in a theme  (avail. on a URL {brand}.stg.larva.pmcdev.io)