### PR TITLE
BR-3030: Add pullquote memo prototype.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unpublished Changes
+* Adds the pullquote.memo prototype that is referenced by some brands.
 
 ## 1.59.0 12-12-2023
 * Add Author Bio and Author Bio Item Modules.

--- a/packages/larva-patterns/modules/pullquote/pullquote.memo.js
+++ b/packages/larva-patterns/modules/pullquote/pullquote.memo.js
@@ -1,4 +1,5 @@
 const clonedeep = require( 'lodash.clonedeep' );
 const pullquote = clonedeep( require( './pullquote.prototype' ) );
 
+pullquote.pullquote_classes += ' memo';
 module.exports = pullquote;

--- a/packages/larva-patterns/modules/pullquote/pullquote.memo.js
+++ b/packages/larva-patterns/modules/pullquote/pullquote.memo.js
@@ -1,0 +1,4 @@
+const clonedeep = require( 'lodash.clonedeep' );
+const pullquote = clonedeep( require( './pullquote.prototype' ) );
+
+module.exports = pullquote;


### PR DESCRIPTION
This change adds the pullquote.memo prototype that is referenced by some brands.

Ticket: https://penskemedia.atlassian.net/browse/BR-3030

### Make sure you complete these items:

- [x] Updated root CHANGELOG.md with summary of changes under `Unpublished` section
- [ ] `npm run prod` in this repo outputs expected changes (excepting the issue with re-ordered partials in larva-css algorithms partials - see [LRVA-1885](https://jira.pmcdev.io/browse/LRVA-1885))
- [ ] If adding a new pattern, in the PR comment, included a screenshot and link to the static Vercel deployment
- [ ] If changes to build scripts or the Node.js server, tested changes in pmc-spark [via a pre-release](https://confluence.pmcdev.io/x/XhOeAw)
- - If changes to build tools: npm scripts `prod`, `lint`, and `dev` scripts run as expected
- - If changes to Larva server: Static site generates as expected in a theme  (avail. on a URL {brand}.stg.larva.pmcdev.io)