### PR TITLE
PASE-1974: pmc-larva should support cookie consent category

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unpublished Changes
+* Update webFontConfig to support cookie consent
 * Update Lerna to V8 (does not appear to fix any publishing issues)
 
 ## 1.60.0 01-02-2024

--- a/packages/larva-js/src/utils/webfontConfig.js
+++ b/packages/larva-js/src/utils/webfontConfig.js
@@ -33,7 +33,8 @@ const webFontConfig = {
 						pmc.cookie.set(
 							'iw_fonts_loaded',
 							1,
-							7 * 24 * 60 * 60
+							7 * 24 * 60 * 60,
+							'C0002' // Require functional cookie consent.
 						);
 					}
 					console.log( 'fonts loaded ' + type );

--- a/packages/larva-js/src/utils/webfontConfig.js
+++ b/packages/larva-js/src/utils/webfontConfig.js
@@ -34,6 +34,7 @@ const webFontConfig = {
 							'iw_fonts_loaded',
 							1,
 							7 * 24 * 60 * 60,
+							'',
 							'C0002' // Require functional cookie consent.
 						);
 					}

--- a/packages/larva-js/src/utils/webfontConfig.js
+++ b/packages/larva-js/src/utils/webfontConfig.js
@@ -35,7 +35,7 @@ const webFontConfig = {
 							1,
 							7 * 24 * 60 * 60,
 							'',
-							'C0002' // Require functional cookie consent.
+							'C0003' // Require functional cookie consent.
 						);
 					}
 					console.log( 'fonts loaded ' + type );


### PR DESCRIPTION
Per PASE-1974, we need to check for OneTrust cookie consent before setting cookie using `pmc.cookie.set()`. This passes in a category of 'functional' for the `webfont loaded` cookie setting.

Relates to https://github.com/penske-media-corp/pmc-plugins/pull/4102/

- [x] Updated root CHANGELOG.md with summary of changes under `Unpublished` section
