### PR TITLE
larva-patterns - Adds new kicker image support to the article kicker module.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unpublished Changes
-
-## 1.67.0 11-16-2024
 * larva-patterns - Adds new kicker image support to the article kicker module.
 
 ## 1.66.4 11-05-2024

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unpublished Changes
 
+## 1.67.0 11-16-2024
+* larva-patterns - Adds new kicker image support to the article kicker module.
+
 ## 1.66.4 11-05-2024
 * Remove Helvetica Fallback Fonts from body font in Rollingstone 2022
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ important information.
 Clone this repository then, from the root, run the following commands:
 
 ```
+nvm use
 sh scripts/install-dependencies.sh
 ```
 

--- a/packages/larva-patterns/modules/article-kicker/article-kicker.prototype.js
+++ b/packages/larva-patterns/modules/article-kicker/article-kicker.prototype.js
@@ -3,4 +3,5 @@ module.exports = {
 	article_kicker_text: 'Article Kicker',
 	article_kicker_url: '#',
 	article_kicker_link_classes: '',
+	article_kicker_image_markup: '',
 };

--- a/packages/larva-patterns/modules/article-kicker/article-kicker.twig
+++ b/packages/larva-patterns/modules/article-kicker/article-kicker.twig
@@ -2,11 +2,13 @@
 	{% if article_kicker_url %}
 		<a href="{{ article_kicker_url }}" class="article-kicker-link {{ article_kicker_link_classes }}">
 	{% endif %}
-		{% if c_svg %}
+		{% if article_kicker_image_markup %}
+			{{ article_kicker_image_markup }}
+		{% elseif c_svg %}
 			{% include "@larva/components/c-svg/c-svg.twig" with c_svg %}
 		{% else %}
 			{{ article_kicker_text }}
-		{% endif %} 
+		{% endif %}
 	{% if article_kicker_url %}
 		</a>
 	{% endif %}

--- a/packages/larva-patterns/modules/article-kicker/article-kicker.twig
+++ b/packages/larva-patterns/modules/article-kicker/article-kicker.twig
@@ -4,10 +4,12 @@
 	{% endif %}
 		{% if article_kicker_image_markup %}
 			{{ article_kicker_image_markup }}
-		{% elseif c_svg %}
-			{% include "@larva/components/c-svg/c-svg.twig" with c_svg %}
 		{% else %}
-			{{ article_kicker_text }}
+			{% if c_svg %}
+				{% include "@larva/components/c-svg/c-svg.twig" with c_svg %}
+			{% else %}
+				{{ article_kicker_text }}
+			{% endif %}
 		{% endif %}
 	{% if article_kicker_url %}
 		</a>


### PR DESCRIPTION
larva-patterns - Adds new kicker image support to the article kicker module.

### Make sure you complete these items:

- [x] Updated root CHANGELOG.md with summary of changes under `Unpublished` section
- [x] `npm run prod` in this repo outputs expected changes (excepting the issue with re-ordered partials in larva-css algorithms partials - see [LRVA-1885](https://jira.pmcdev.io/browse/LRVA-1885))
- [ ] If adding a new pattern, in the PR comment, included a screenshot and link to the static Vercel deployment
- [ ] If changes to build scripts or the Node.js server, tested changes in pmc-spark [via a pre-release](https://confluence.pmcdev.io/x/XhOeAw)
- - If changes to build tools: npm scripts `prod`, `lint`, and `dev` scripts run as expected
- - If changes to Larva server: Static site generates as expected in a theme  (avail. on a URL {brand}.stg.larva.pmcdev.io)