### PR TITLE
CORP-620: Add aria-label attribute for c-button component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unpublished Changes
+* Add aria-label attribute for c-button component
 
 ## 1.68.0 02-18-2025
 * Resolve ESLint warnings/errors

--- a/packages/larva-patterns/components/c-button/c-button.twig
+++ b/packages/larva-patterns/components/c-button/c-button.twig
@@ -1,7 +1,15 @@
 {% if c_button_url %}
-	<a class="c-button larva {{ modifier_class }} {{ c_button_classes }}" href="{{ c_button_url }}" target="{{ c_button_target_attr }}" rel="{{ c_button_rel_attr }}" {{ wp_action( 'pmc_do_render_custom_ga_tracking_attr', c_button_ga_tracking ) }}>
+	<a class="c-button larva {{ modifier_class }} {{ c_button_classes }}" href="{{ c_button_url }}" target="{{ c_button_target_attr }}" rel="{{ c_button_rel_attr }}" {{ wp_action( 'pmc_do_render_custom_ga_tracking_attr', c_button_ga_tracking ) }}
+		{% if c_button_aria_label_attr %}
+			aria-label="{{ c_button_aria_label_attr }}"
+		{% endif %}
+	>
 {% else %}
-	<button class="c-button larva {{ modifier_class }} {{ c_button_classes }}" type="{{ c_button_type_attr }}">
+	<button class="c-button larva {{ modifier_class }} {{ c_button_classes }}" type="{{ c_button_type_attr }}"
+		{% if c_button_aria_label_attr %}
+			aria-label="{{ c_button_aria_label_attr }}"
+		{% endif %}
+	>
 {% endif %}
 
 	<span class="c-button__inner {{ c_button_inner_classes }}">


### PR DESCRIPTION
## Summary

Add aria-label attribute for c-button component
### Make sure you complete these items:

- [x] Updated root CHANGELOG.md with summary of changes under `Unpublished` section
- [x] `npm run prod` in this repo outputs expected changes (excepting the issue with re-ordered partials in larva-css algorithms partials - see [LRVA-1885](https://jira.pmcdev.io/browse/LRVA-1885))
- [ ] If adding a new pattern, in the PR comment, included a screenshot and link to the static Vercel deployment
- [ ] If changes to build scripts or the Node.js server, tested changes in pmc-spark [via a pre-release](https://confluence.pmcdev.io/x/XhOeAw)
- - If changes to build tools: npm scripts `prod`, `lint`, and `dev` scripts run as expected
- - If changes to Larva server: Static site generates as expected in a theme  (avail. on a URL {brand}.stg.larva.pmcdev.io)