### PR TITLE
Add context-gardener pack

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,116 @@
+<!-- context-gardener pack · reviewed c4cc923 -->
+
+## Non-Inferable Facts
+
+### Escaping & pattern authoring (read `references/pattern-authoring.md` before editing any twig/prototype)
+- Escaping is **keyword-driven, not type-driven**, on both the Twing server render and the
+  generated PHP. In `packages/twig-to-php-parser/lib/twig-to-php-parser.php:140-176` a `strpos`
+  substring match on a mustache var's data-name selects the escaper (`_url`→`esc_url`,
+  `_class`/`_name`/`_attr`/`_attributes`→`esc_attr`, `_text`→`esc_html`, `_markup` or
+  `|markup`→`wp_kses_post`, `_wp_action`→`do_action`). **A var name matching no keyword emits no
+  `<?php echo ?>` wrapper — silent unescaped/broken output, not an error.** Name new output vars
+  to hit the intended keyword.
+- Adding a new twig function needs THREE coordinated edits or parsing silently breaks: register
+  in `packages/larva/lib/server.js` `twing.addFunction`, add a parse fn in
+  `packages/twig-to-php-parser/lib/twig-to-php-parser.php`, and wire it into `twig_to_php_parser`.
+- The `|markup` filter (`server.js:43`, `is_safe:['html']`) and twig `|raw` are the only
+  html-safe server-render output paths; everything else auto-escapes. New raw-HTML-in-a-loop
+  must use `|markup`.
+- Any new pattern must clone-before-mutate (see Use This Not That); pattern files follow strict
+  `<name>.prototype.js` + `<name>.twig`/`.html` naming or the CLI won't discover them.
+
+### larva-js interface modules (read `references/js-hook-contracts.md` before adding/binding behavior)
+- Interface-module inits (`querySelectorAll(hook).forEach(new Class(el))`) are **not
+  auto-invoked**. Only `packages/larva-js/src/video-showcase.js` (Collapsible, Flickity,
+  VideoShowcase) and `packages/larva-js/src/larva-ui/index.js` (LarvaUiToggle, SideSkinAd) are
+  wired. Every other module must be manually imported + called in the consuming theme entry, or
+  it silently does nothing. A hook class omitted from markup = behavior never binds.
+- A behavior class must stamp its instance onto a `pmc<Name>` DOM property for cross-instance
+  access + re-init guards. Do-not-copy: `packages/larva-js/src/interface/ProfileFilter/index.js:5`
+  stamps `el.ProfileFilter` (no `pmc` prefix) — the test passes only because the constructor also
+  stamps `pmcProfileFilter`.
+- Silent contract mismatch: `ProfileFilter.js:230-237` toggles the bare class `a-hidden`, but
+  larva-css defines only `.lrv-a-hidden` (`packages/larva-css/src/02-algorithms/a-hidden/a-hidden.common.inline.scss`).
+  A consumer loading only larva-css sees no hide effect. Bare `a-`/`u-`/`js-` classes are
+  project-owned; larva-css output classes carry the `.lrv-` namespace, and larva-js references
+  bare hooks for project markup but `lrv-a-`/`lrv-u-` for larva-css-owned classes.
+- `packages/larva-js/src/interface/SideSkinAd/index.js` is an inbound postMessage gate: it reflows
+  only when `e.data` starts with the literal `pmcadm:dfp:skinad:parameters` AND an atlas skin object
+  exists on `window`, then calls `atlasSkinObj.refresh_skin_rails()`. `reflowForSideSkinAd` is
+  idempotent via
+  `window.pmc_side_skin_classes_removed` and strips every `@desktop-xl` class.
+- The `@larva-js/interface/*` module specifier is NOT resolved by this package (webpack aliases
+  only `@npm`); the consuming build must provide it.
+
+### Build, config & CLI
+- `packages/larva/lib/utils/getAppConfiguration.js` falls back to a per-key `defaultConfig` on a
+  missing key or require error, and overrides CWD to `__tests__/fixtures` when `NODE_ENV=test`
+  (so project-level tests can't supply their own config). `packages/backstopjs-config/lib/getConfig.js`
+  and `packages/twig-to-php-parser/lib/getConfig.js` ship byte-identical copies of each other (both
+  catch and return `undefined`, no default fallback); only `getAppConfiguration` has the per-key
+  `defaultConfig` fallback — see Use This Not That.
+- SCSS build does NOT fail on stylelint errors: `packages/larva/scripts/config/gulpfile.js:35`
+  sets `failAfterError:false`. The build also strips the UTF-8 BOM from every compiled CSS file.
+- `prod-scss --generate-important-variants` emits a second `-important.css` with `!important` on
+  every declaration. `larva prod` with no flag runs the full chain (parse → write-json →
+  prod-scss → prod-js → build-icons); each stage is individually skippable via its flag
+  (`packages/larva/scripts/prod.js`).
+- CI (`.github/workflows/test.yml`) runs Node 18 only and fails on any test/lint error;
+  `.github/workflows/regressions.yml` runs backstop on every push (start server, `sleep 5`, test);
+  reference-screenshot updates are a separate manual `workflow_dispatch` (`approval.yml`).
+- A `pre-push` git hook (`packages/larva/bin/pre-push`, installed via npm postinstall by
+  `install-hooks.js`) blocks push when the consuming project's assets/package.json pins an older
+  `@penskemediacorp/larva` than npm's latest, unless `--force`/`-f`/`--no-verify`; caches latest
+  24h in `os.tmpdir()`.
+- Monorepo is lerna **fixed-version** (`lerna.json`, all packages at one version) — releases bump
+  every package in lockstep, and `larva` pins siblings at `^`same. Do NOT upgrade `globby` past 11
+  unless migrating the whole app to ESM (`package.json` `//` note).
+- Undeclared deps that work only by hoist: `mkdirp` (`build-icons.js`, `generateStatic.js`) and
+  bare `lodash` (`jest-setup.js:18`; root declares only `lodash.clonedeep`) are in no package.json.
+- larva-scss ships Sass source only (no compiled CSS); its generator mixins are **deprecated as of
+  8.7.0-alpha** (`packages/larva-scss/README.md`) — the recommended pattern for new utility code is
+  to iterate a token map directly, NOT to copy the generators. All public generators take a trailing
+  `$NAMESPACE:''` param that must be threaded, and `_a-font.scss` is code-generated from
+  larva-tokens (not hand-written).
+
+### External boundaries
+- This monorepo consumes many host-supplied identifiers (JS globals, a REST route, WP hooks,
+  render-context vars, config keys) that are defined **nowhere in the repo** and fail silently at
+  runtime when absent. Full verified catalog: `references/external-boundaries.md`.
+
+## Use This Not That
+
+- **Cloning pattern data:** `require('@penskemediacorp/larva').clone` and its alias
+  `__experimentalCloneWithFallback` both point at `packages/larva/lib/utils/clonePatternData.js`
+  (project-patterns-dir first, silent fallback to the larva dir; layer-override-aware, takes a
+  string path). Use it for cross-pattern includes a downstream layer may override. Use plain
+  `lodash.clonedeep(require(relpath))` only for a same-package sibling. Do not object-spread a
+  prototype (shallow — mutates the shared singleton).
+- **Reading config:** inside the `larva` package use `packages/larva/lib/utils/getAppConfiguration.js`
+  — it falls back to per-key `defaultConfig` on a missing key. `packages/backstopjs-config/lib/getConfig.js`
+  and `packages/twig-to-php-parser/lib/getConfig.js` ship **byte-identical** copies of each other:
+  both `throw` an internal `Error` on a missing key, catch it, `console.error`, and return
+  `undefined` — no default fallback. Only `getAppConfiguration` differs. (`packages/backstopjs-config/index.js:45`
+  also references an undefined `urlFromCli`; `packages/backstopjs-config/lib/utils.js:29` throws via
+  `chalk` it never requires.)
+- **Utility SCSS:** iterate a token map directly for new utilities; do not copy the deprecated
+  larva-scss generator mixins. Between the two utility styles, `token-utility-generator` emits a
+  dual declaration (static value THEN `var(--token,value)`, needing larva-tokens custom properties
+  at runtime) while `basic-utility-generator` emits only the static value.
+- **MobileHeightToggle prefix:** the trigger/target/root triple must all use the same prefix —
+  plain `js-MobileHeightToggle*` OR `lrv-js-MobileHeightToggle*`, never mixed, or the toggle
+  no-ops. The init reads only `.lrv-js-MobileHeightToggle`.
+- **Includes:** use the `@larva/<type>/<name>/<name>.twig` namespace, not a relative path (won't
+  resolve). Exceptions `c-logo`/`c-svg` are deviations, not the pattern.
+
+## References
+
+- `references/pattern-authoring.md` — read before editing any `.twig`/`.prototype.js`: the
+  keyword-driven escaping table, file-naming/discovery rules, include + hook conventions, `_data`
+  shape rules, and the catalog of in-code pattern bugs not to replicate.
+- `references/js-hook-contracts.md` — read before adding or wiring larva-js behavior: per-module
+  root/child/state hooks, which inits are auto-wired vs manual, and the `pmc<Name>` stamp rule.
+- `references/external-boundaries.md` — read when a runtime value is missing or a global/route/WP
+  hook is referenced: the full list of identifiers this repo consumes but never defines.
+
+## Human Notes

--- a/references/external-boundaries.md
+++ b/references/external-boundaries.md
@@ -1,0 +1,53 @@
+# External boundaries — identifiers consumed here, defined nowhere in this repo
+
+Each was confirmed absent by repo-wide grep. A host WordPress theme/plugin or ad/analytics
+platform must supply them; nothing here defines or validates them, so a missing one fails at
+runtime (usually silently), not at build.
+
+## JS globals (browser)
+- `window.pmc_common_urls` — `webfontConfig.js:46` reads `.current_theme_uri`; `common.entry.js`
+  reads `.pmc_larva_uri` for the SVG sprite location (falls back to `/assets/build/svg/defs/sprite.defs.svg`).
+- `window.pmc_jwplayer` (playJW), `pmcCnx` (playConnatix), and the hard-coded Connatix capi token
+  URL — `VideoShowcase.js:262,264,312`. Video playback no-ops without them.
+- `window.pmc_dfp_skin` / `window.pmc.skinAds` + an atlas skin object exposing
+  `refresh_skin_rails()` — `SideSkinAd/index.js:9-11,27`; `base.html` stubs `pmc_dfp_skin` only
+  when `query.has_side_skins`.
+- `window.pmc` (cookie API), `WebFont`, cookie `iw_fonts_loaded` — `webfontConfig.js` (loads PT
+  Sans, Teko, Argent CF).
+- `wp.template` script IDs `profile-card` (ProfileFilter) and `trigger-social-share-${id}`
+  (VideoShowcase) — the `<script type="text/html">` templates are not in repo.
+
+## REST / service endpoints
+- `/wp-json/pmc_core/v1/pmc_core_modules/pmc-profiles` — `ProfileFilter.js:52`; route owned by
+  the PMC Profiles plugin.
+- Swiftype: `data-st-search-form="small_search_form"` (`search-form.twig`) is a widget mount +
+  install key; branch flag `search_form_is_swiftype` is host-supplied.
+
+## Twig / PHP render context (larva server or generated-PHP host supplies)
+- Render vars injected by `packages/larva/lib/server.js` (each set via `req.params.*`): `brand,
+  source, type, name, variant, variants, data, spec, colors, font_styles, pattern_nav, query,
+  json_pretty`.
+- `compat_class` — consumed at `base.html:41` (`<body class="lrv-u-margin-a-00 {{ compat_class }}">`)
+  but never assigned anywhere in `packages/larva` (server.js sets it on no `req.params`); the host
+  render context supplies it.
+- Twig filters/functions `markdown`, `markup`, `source()`, `wp_action(...)` — defined in
+  `server.js`; `wp_action` returns `''` at server render, becomes `do_action()` in generated PHP.
+- WP action name `pmc_do_render_custom_ga_tracking_attr` (`c-button.twig`, `o-icon-button.twig`)
+  — the hook string is defined nowhere here (external WP hook).
+- Generated-PHP symbols emitted by `twig-to-php-parser.php`: plugin mode
+  `\PMC\Larva\Pattern::get_instance()->render_pattern_template`,
+  `\PMC\Larva\Config::get_instance()->get('brand_directory')`; non-plugin `\PMC::render_template`;
+  constants `PMC_CORE_PATH` / `CHILD_THEME_PATH`.
+
+## Dead / unconsumed hooks (present in markup, no repo reader)
+- `data-dropdown` (via `o_nav_data_attributes`, `o-nav.twig`) — zero consumers.
+- `data-pmc-sp-product` / `data-category-name` (`o-icon-button.twig`) — external analytics/shopping.
+- `data-lazy-src`/`-srcset`/`-sizes` (`c-lazy-image`) — no larva-js hydrator; only test fixtures
+  reference them. Lazy-load reader is external.
+- `CustomEvent('firstVideoPlay')` dispatched at `VideoShowcase.js:390` — no in-repo listener.
+
+## Config keys read from a consuming project's `larva.config.js` (not defaulted here)
+- `patterns.ignoredModules`, `backstop.larvaModules`, `backstop.testPaths`, `themeAssets`,
+  `themePatternsDir`, `phpBinaryPath` (twig-to-php-parser; undocumented, no default, no validation).
+- `pmc.stylelintrc.json` — `stylelint-config/lib/custom-formatter.js:6` unconditionally reads +
+  `JSON.parse`s `<cwd>/pmc.stylelintrc.json`; throws for any project lacking it.

--- a/references/js-hook-contracts.md
+++ b/references/js-hook-contracts.md
@@ -1,0 +1,34 @@
+# larva-js interface-module hook contracts
+
+Each larva-js interface module binds to markup by class/data-attr hooks. The init in each
+module's `index.js` does `querySelectorAll(hook).forEach(el => new Class(el))` and is **not
+auto-invoked** — only `video-showcase.js` (Collapsible + Flickity + VideoShowcase) and
+`larva-ui/index.js` (LarvaUiToggle + SideSkinAd) are wired into entries. Any other module
+(EmailCapture, ExpandableSearch, MegaMenu, MobileHeightToggle, PopOver, ProfileFilter,
+SelectNav, TabsManager, Tooltip, Navigable) must be manually imported + called in the
+consuming theme's entry, or it silently does nothing. Omitting a hook class = behavior never
+binds. A hook may be a literal in `.twig` OR appended to a `*_classes` prototype string — the
+two are not interchangeable per module; wrong side never reaches the DOM.
+
+Idempotency/instance access: an interface class stamps its instance onto a `pmc<Name>` DOM
+property (Collapsible→`pmcCollapsible`, MobileHeightToggle→`pmcMobileHeightToggle`, etc.).
+**Do-not-copy divergence:** `ProfileFilter/index.js:5` stamps `el.ProfileFilter` (no `pmc`
+prefix); the constructor separately stamps `pmcProfileFilter` (`ProfileFilter.js:24`) — the
+test only passes because of the second stamp.
+
+| Module | Init wired? | Root hook | Child/state hooks | Notes |
+|--------|-------------|-----------|-------------------|-------|
+| Collapsible | yes (video-showcase.js) | `[data-collapsible]` (value=initial state) | `[data-collapsible-toggle]`, `[data-collapsible-panel]`; toggle opt `always-show`; panel `data-collapsible-breakpoint` (mobile-only) | JS writes `dataset.collapsible=expanded/collapsed` + toggles `.is-expanded`; expand runs unscoped `document.querySelector('[data-collapsible-toggle] + li > a').focus()` — throws if no match (`Collapsible.js`) |
+| Flickity | yes (video-showcase.js) | `.js-Flickity` + `.js-Flickity--*` config | every direct child cell `.js-Flickity-cell` (cellSelector) — cell missing the class is dropped | init reads only 4 boolean modifiers `isContained/isFreeScroll/isWrapAround/pageDots`, NOT `data-flickity-options`. SCSS defines many sizing modifiers (`--thirds/--fifths/--nav-*`) the JS never reads. Typo `js-Flickity--isFreeScrol` (missing `l`) in `newswire.prototype.js:49` is silently dead |
+| VideoShowcase | yes (video-showcase.js) | `[data-video-showcase]` | trigger `[data-video-showcase-trigger]`/`-type(youtube\|jwplayer)`/`-dek`/`-title`/`-permalink`; player `[data-video-showcase-player]`/`-iframe`/`-jwplayer`; output `.js-VideoShowcase-title`/`-dek` (appended to child `*_classes` in prototype, not twig) | adds `.is-playing` to active trigger; renders social share via `wp.template('trigger-social-share-${id}')` + re-inits Collapsibles; `data-video-showcase-autoplay` fires first trigger immediately |
+| MobileHeightToggle | no (manual) | `.lrv-js-MobileHeightToggle` | `.lrv-js-MobileHeightToggle-trigger` | init takes a `width` arg, instantiates only `<768`, destroys `>=768`; **prefix contract**: plain `js-MobileHeightToggle*` vs `lrv-js-MobileHeightToggle*` — trigger/target/root must share ONE prefix or the toggle no-ops. Only 04-js SCSS bundled into larva-css |
+| ExpandableSearch | no (manual) | `.js-ExpandableSearch` | `-trigger`, `-target`, `js-fade`/`js-fade-is-out` state; twig `data-header-search-trigger` | toggles `js-fade-is-out/-in` but paired SCSS defines only `.is-ExpandableSearch-open` (the `js-fade-*` classes live outside larva-css); registers document/body/focusin listeners never removed on close (leak) |
+| MegaMenu | no (manual) | `.js-MegaMenu` | trigger `js-MegaMenu-Trigger` appended to `o_icon_button_classes` in header.prototype/header.article/header-sticky.prototype | open state `is-mega-open` on `document.documentElement`, cleared on Escape; skips focus-trap when node also has `.mega-menu__main`; a new header omitting the trigger hook leaves the menu unopenable |
+| SelectNav | no (manual) | `.js-SelectNav` | `.js-SelectNav-select`, option `data-select-url` | redirect handler wired ONLY when the element also carries `.js-SelectNav-redirect`; a plain `.js-SelectNav` inits but does nothing |
+| EmailCapture | no (manual) | `.lrv-js-EmailCapture` (form) | hidden `__successPage` input with `data-email-capture-success-url` | reads `data-email-capture-success-url`, writes `${base}&email=${email}` back to `.value` on blur/keyup; producer is `o-email-capture-form` (hard-codes ExactTarget `__contextName`/`__executionContext`/`__successPage`) |
+| ProfileFilter | yes (index registered) but init manual | `.js-ProfileFilter` | `-results`, `-form`, `-submit`, `-loadMore` (loadMore only in `.profile` variant) | builds REST URL stripping `filter_` prefix; progressive enhancement: `preventDefault`+fetch only when `window.fetch`; toggles bare `a-hidden` (see Non-Inferable) |
+| SideSkinAd | yes (larva-ui) | postMessage-gated (no DOM hook) | — | see Non-Inferable — reflows only on `pmcadm:dfp:skinad:parameters` postMessage + an atlas skin object |
+| LarvaUiToggle | yes (larva-ui) | `.js-LarvaUiToggle-button` | `.js-LarvaUiToggle-panel` | persists visibility to localStorage `pmcIsLarvaUiHidden`, toggles `lrv-a-hidden` |
+| PopOver | no (manual) | `.js-PopOver` | `.js-PopOver-target` | author-popover; producer via `author_button_classes`/`author_detail_outer_classes` |
+| Tooltip | no (manual) | `.js-Tooltip-parent` (wrapper) | `.js-Tooltip` (content) | `o-account-menu` flyout |
+| header sticky-scroll | (theme) | outer `js-hide-when-sticky` | sticky clone `js-show-when-sticky js-sticky-header-slidedown` | both `is_home` twig branches must repeat all three hooks |

--- a/references/pattern-authoring.md
+++ b/references/pattern-authoring.md
@@ -1,0 +1,71 @@
+# Pattern authoring — larva-patterns conventions, escaping, known bugs
+
+## File layout (CLI discovers by this exact naming)
+Every pattern dir holds `<name>.prototype.js` (CJS default-data export) plus `<name>.twig`
+(components/objects/modules) or `<name>.html` (algorithms/tests). Variant data is
+`<name>.<variant>.js`; legacy `<name>.json` still resolves as a fallback (`getPatternData.js`).
+`getPatternData`'s default variant is the reserved name `prototype`. A broken/missing data file
+returns an **error object rendered as data** (silent UI failure), not an error. Algorithm
+patterns have empty `.prototype.js` (no data block). Pattern type is derived from the 2-char
+name prefix: `c-`→components, `o-`→objects, else modules — enforced identically in
+`getPatternType.js` and `twig-to-php-parser.php:261` (`parse_include_path`).
+
+## Escaping — the single most important authoring rule
+Escaping is **keyword-driven, not type-driven**, on BOTH render paths:
+- Server render (Twing): all interpolation auto-escapes except the `|markup` filter
+  (`is_safe:['html']`, `server.js:43`) and twig `|raw`. `*_markup` prototype fields are rendered
+  through `|raw` (unescaped HTML); `*_text` fields auto-escape.
+- Generated PHP (`twig-to-php-parser.php:140-176`): a `strpos` substring match on the mustache
+  var's data-name picks the escaper. **A var name matching no keyword produces NO
+  `<?php echo ?>` wrapper at all — silent broken output, not an error.**
+
+| data-name substring | PHP escaper |
+|---------------------|-------------|
+| `_url` | `esc_url` |
+| `_class` / `_name` / `_attr` / `_attributes` | `esc_attr` |
+| `_text` | `esc_html` |
+| `_markup` or `\|markup` | `wp_kses_post` |
+| `_wp_action` (or `wp_action(...)`) | `do_action` |
+
+Consequence: a rich-content field named `*_text` double-escapes; a `*_markup` field without
+`|raw` escapes when it should not. Name new output vars to hit the right keyword.
+
+## Twig include + hook conventions
+- Cross-pattern includes use the namespace `@larva/<type>/<name>/<name>.twig` (resolved by the
+  larva server loader and the parser). A raw relative include would not resolve.
+  **Do-not-copy deviation:** `c-logo` and `c-svg` include SVG via relative build path
+  `'../../build/svg/'~name~'.svg'`, not the namespace.
+- Root element convention: `class="<pattern-name> {{ modifier_class }} {{ <pattern>_classes }}"`
+  — a new pattern must expose both hooks. Screen-reader text uses `class="lrv-a-screen-reader-only"`.
+- `<a>` vs `<button>`/`<span>` is selected purely on presence of the `*_url` data field
+  (`c-button` and peers). Objects can depend upward on modules (`o-card`/`o-multiple-product-item`
+  include `@larva/modules/article-kicker`).
+- **Clone-before-mutate invariant:** a variant `.<variant>.js` or a prototype requiring a sibling
+  prototype MUST deep-clone before mutating, or it mutates the shared `module.exports` singleton
+  every importer sees. Two non-equivalent helpers exist — see Non-Inferable / Use-This-Not-That.
+
+## `_data` files
+`getDataSet(filename)` requires `../_data/<filename>.json` and calls **array methods** — the file
+MUST be a bare top-level array. `social-platforms.json` is a bare array (works);
+`brands.json` is object-wrapped `{brands:[...]}` — `getDataSet('brands')` would throw (no such
+consumer exists; `pmc-footer` requires `brands.json` directly).
+
+## Package export gotcha
+`larva-patterns` `index.js` exports only `o_nav` + `o_tease`. Every other cross-package consumer
+deep-requires by path: `@penskemediacorp/larva-patterns/<type>/<name>/<name>.prototype`. The
+package main is NOT the contract.
+
+## Known in-code bugs (do not replicate; fix if touched)
+- `o-icon-button.twig`: gates the anchor on `o_icon_button_url` but sets `href` from
+  `o_button_url` (undefined in prototype) → empty href. `buy-now` works around it by setting both.
+- `o-category-link.twig`: reads `o_category_link_wrap_classes` but the prototype defines
+  `o_category_link_wrap` (boolean) → class renders empty.
+- `o-video-card.twig:62`: renders the `c_title` payload through `c-heading.twig` (should be
+  `c-title.twig`).
+- `a-carousel-grid.overlay.js:4,11`: defines `carousel_grid_overlay_content_class` twice; second
+  shadows first (no-dupe-keys lint disabled).
+- `a-term-content-grid.html:3`: emits literal `\\` into a `class` attribute.
+- `list.twig` recursively re-includes itself for nested `list_items`; the shape must carry
+  `list_type_name` at every level or `<{{list_type_name}}l>` renders as `<l>`.
+- `vlanding-video-card`: opens `<button>`/`<a>` in one `{% if %}` at top, closes it in a matching
+  `{% if %}` at bottom — the two conditions must stay in lockstep.


### PR DESCRIPTION
## What

Adds a [context-gardener](https://github.com/principalwp/context-gardener) pack for this repo: a terse `CLAUDE.md` plus a `references/` folder holding only facts an agent **cannot infer from the code** — the gotchas that bite when you edit patterns, wire JS behaviors, or touch the build.

## Contents

- **`CLAUDE.md`** (machine zone, ~113 lines) — Non-Inferable Facts (keyword-driven escaping on both Twing render and generated PHP; larva-js interface-module wiring; build/config/CLI gotchas; external boundaries), a "Use This Not That" section, and an empty `## Human Notes` zone for your own additions.
- **`references/pattern-authoring.md`** — read before editing any `.twig`/`.prototype.js`.
- **`references/js-hook-contracts.md`** — read before adding/wiring larva-js behavior.
- **`references/external-boundaries.md`** — the identifiers this repo consumes but never defines.

## How it was produced

Generated by the context-gardener pipeline: survey → fan-out (5 scouts over a 782 KB code bucket) → merge → mechanical lint battery (all 0 defects) → adversarial reviewer pass. The reviewer's two findings (a miscategorized `compat_class`, and the two `getConfig.js` copies wrongly called divergent) were both applied.

## Notes for reviewers

The pack is code-derived documentation — no source or behavior changes. Review it like any doc: check the claims against the code. `## Human Notes` is yours; the machine zone above it is regenerated by the tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)